### PR TITLE
(cli): Decrease CLI size by 80%

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.46",
   "author": "Himanshu @himanshu-dixit",
   "repository": "https://github.com/crusherdev/CLI",
-  "main": "index.js",
+  "main": "./src/bin/index.js",
   "private": true,
   "license": "MIT",
   "bin": {
@@ -17,10 +17,11 @@
     "run": "ts-node src/bin/index.ts",
     "build": "webpack && PACKAGE_NAME=crusher-cli node scripts/copyPackageJson.js",
     "build:debug": "webpack && PACKAGE_NAME=crusher-debug node scripts/copyPackageJson.js",
+    "analyzer": "webpack-cli --profile --json > compilation-stats.json",
     "test": "jest"
   },
   "dependencies": {
-    "webpack-bundle-analyzer": "^4.6.1"
+    "ora": "^5.0.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",
@@ -29,6 +30,7 @@
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
     "@commitlint/prompt": "^13.1.0",
+    "@statoscope/webpack-plugin": "^5.24.0",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.4",
@@ -36,6 +38,7 @@
     "axios-mock-adapter": "^1.20.0",
     "boxen": "^5.1.2",
     "chalk": "^4.0.0",
+    "cli-progress": "^3.11.2",
     "cli-ux": "^6.0.9",
     "codecov": "^3.1.0",
     "command-exists": "^1.2.9",
@@ -47,12 +50,13 @@
     "glob": "^7.2.0",
     "husky": "^7.0.2",
     "ini": "^3.0.0",
-    "inquirer": "^6.2.0",
+    "inquirer": "^6.1.0",
     "jest": "^27.2.0",
     "jsonfile": "^6.1.0",
     "lint-staged": "^11.1.2",
     "localtunnel": "^2.0.2",
     "nock": "^13.2.4",
+    "open": "^8.4.0",
     "prettier": "^2.4.1",
     "replace-json-property": "^1.4.1",
     "semver": "^7.3.7",
@@ -62,6 +66,8 @@
     "typescript": "^4.1.3",
     "uuid": "^8.3.2",
     "webpack": "5.73.0",
+    "webpack-bundle-analyzer": "^4.6.1",
+    "webpack-bundle-size-analyzer": "^3.1.0",
     "webpack-cli": "^4.10.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,9 @@
     "build:debug": "webpack && PACKAGE_NAME=crusher-debug node scripts/copyPackageJson.js",
     "test": "jest"
   },
-  "dependencies": {  },
+  "dependencies": {
+    "webpack-bundle-analyzer": "^4.6.1"
+  },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",
     "@babel/preset-env": "^7.16.11",
@@ -44,6 +46,8 @@
     "fs-extra": "^10.0.0",
     "glob": "^7.2.0",
     "husky": "^7.0.2",
+    "ini": "^3.0.0",
+    "inquirer": "^6.2.0",
     "jest": "^27.2.0",
     "jsonfile": "^6.1.0",
     "lint-staged": "^11.1.2",
@@ -56,10 +60,8 @@
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.3",
     "typescript": "^4.1.3",
+    "uuid": "^8.3.2",
     "webpack": "5.73.0",
-    "webpack-cli": "^4.10.0",
-    "ini": "^3.0.0",
-    "inquirer": "^6.2.0",
-    "uuid": "^8.3.2"
+    "webpack-cli": "^4.10.0"
   }
 }

--- a/packages/cli/scripts/copyPackageJson.js
+++ b/packages/cli/scripts/copyPackageJson.js
@@ -22,6 +22,8 @@ const patchVersion = (versionStr) => {
     if (fs.existsSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"))) {
       fs.unlinkSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"));
     }
+
+    fs.writeFileSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"), JSON.stringify(packageJSON), "utf8");  
     
     fs.writeFileSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"), JSON.stringify(packageJSON), "utf8");  
   }).catch((err) => {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,8 +1,21 @@
-import { Command, program } from "commander";
-import * as packgeJSON from "../../package.json";
-import fs from "fs";
-import path from "path";
 import chalk from "chalk";
+
+import whoami from "./whoami";
+import info from "./info";
+import logout from "./logout";
+import login from "./login";
+import tunnel from "./tunnel";
+import invite from "./invite";
+import init from "./init";
+import token from "./token";
+import testCreate from "./test/create";
+import testRun from "./test/run";
+
+const CommandRegister = {
+  whoami,info, logout, login, token, tunnel, invite, init,
+  "test:create": testCreate,
+  "test:run":testRun
+}
 
 export default class CommandBase {
   constructor() {}
@@ -39,30 +52,13 @@ export default class CommandBase {
 
   async run() {
     const type = process.argv[2];
+
     if (
-      type &&
-      fs.existsSync(
-        path.resolve(
-          __dirname,
-          "../commands/",
-          `${this.getPathForType(type)}.${
-            process.env.NODE_ENV === "production" ? "js" : "ts"
-          }`
-        )
-      )
+      type
     ) {
-      //@ts-ignore
-      const requireCommand =typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
       try {
-        await (new (requireCommand(
-          path.resolve(
-            __dirname,
-            "../commands/",
-            `${this.getPathForType(type)}.${
-              process.env.NODE_ENV === "production" ? "js" : "ts"
-            }`
-          )
-        ).default)()).init();
+        const commandInstance = new CommandRegister[type]();
+        commandInstance.init()
       } catch (err) {
         if (err.message === "SIGINT") process.exit(1);
         console.log(chalk.red("Error:"), err.message);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -61,6 +61,10 @@ export default class CommandBase {
         commandInstance.init()
       } catch (err) {
         if (err.message === "SIGINT") process.exit(1);
+        if(err.message.includes("not a constructor")){
+          console.log(`No such command -> ${type }. Run --help.`);
+          process.exit(1);
+        }
         console.log(chalk.red("Error:"), err.message);
         process.exit(1);
       }

--- a/packages/cli/src/commands/invite.ts
+++ b/packages/cli/src/commands/invite.ts
@@ -1,10 +1,9 @@
 import { Command } from "commander";
-import * as packgeJSON from "../../package.json";
-
-import * as inquirer from "inquirer";
-import cli from "cli-ux";
+import inquirer from 'inquirer';
 import { getProjectConfig } from "../utils/projectConfig";
 import { getInviteLink, inviteProjectMembers } from "../utils/apiUtils";
+import ora from 'ora';
+
 
 const program = new Command();
 program.addHelpText(
@@ -53,9 +52,10 @@ export default class CommandBase {
       },
     ]);
     console.log("\n");
-    await cli.action.start("Preparing a cryptic invite code.");
+    const spinner = ora('Preparing a cryptic invite code').start();
+
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    await cli.action.stop();
+    spinner.stop()
 
     if (res.method === 0) {
       const emailsRes = await inquirer.prompt([
@@ -66,12 +66,12 @@ export default class CommandBase {
         },
       ]);
       console.log("Email res is", emailsRes.emails);
-      await cli.action.start("Sending invites");
-      const inviteRes = await inviteProjectMembers(
-        projectConfig.project,
-        emailsRes.emails.split(",")
-      );
-      await cli.action.stop();
+      const spinner2 = ora('Sending invites').start();
+
+      await console.log("Sending invites");
+
+      spinner2.stop()
+
       console.log(
         "\nInvited your folks to use crusher!. Ask them to check there mail."
       );

--- a/packages/cli/src/commands/test/create.ts
+++ b/packages/cli/src/commands/test/create.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { loadUserInfoOnLoad } from "../../utils/hooks";
 import { getUserInfo } from "../../state/userInfo";
 import { getRecorderDistCommand, resolvePathToAppDirectory } from "../../utils/utils";
-import cli from "cli-ux";
+
 import { getProjectConfig, getProjectConfigPath } from "../../utils/projectConfig";
 import { execSync } from "child_process";
 import localTunnel from "localtunnel";
@@ -70,7 +70,7 @@ export default class CommandBase {
       tunnel = await createTunnel(port);
       const host = tunnel.url;
 
-      await cli.log("\nServing at " + host + " now \n");
+      await console.log("\nServing at " + host + " now \n");
     }
 
     const projectConfig = getProjectConfig();
@@ -83,11 +83,11 @@ export default class CommandBase {
   
     execSync(`${getRecorderDistCommand()} ${customFlags} --no-sandbox --open-recorder --projectId=${projectId} --token=${userToken}`, {stdio: "ignore"});
 
-    cli.log("Created your test. Few command that might be helpful\n");
-    cli.log("1.) Run all tests in your project");
-    cli.log(`${chalk.hex("9A4AFF")(`npx crusher-cli test:run`)}`);
+    console.log("Created your test. Few command that might be helpful\n");
+    console.log("1.) Run all tests in your project");
+    console.log(`${chalk.hex("9A4AFF")(`npx crusher-cli test:run`)}`);
 
-    cli.log("2.) Invite team members to the project");
-    cli.log(`${chalk.hex("9A4AFF")(`npx crusher-cli invite`)}`);
+    console.log("2.) Invite team members to the project");
+    console.log(`${chalk.hex("9A4AFF")(`npx crusher-cli invite`)}`);
   }
 }

--- a/packages/cli/src/commands/tunnel.ts
+++ b/packages/cli/src/commands/tunnel.ts
@@ -1,10 +1,7 @@
 import { Command } from "commander";
 
-import { cli } from "cli-ux";
-import { runTests } from "../utils/apiUtils";
 import { getProjectConfig } from "../utils/projectConfig";
 import { loadUserInfoOnLoad } from "../utils/hooks";
-import { getUserInfo } from "../state/userInfo";
 import { Cloudflare } from "../module/cloudflare";
 import fs from "fs";
 

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -13,7 +13,6 @@ program.parse(process.argv);
 
 export default class CommandBase {
   constructor() {
-
   }
 
   async init() {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -11,9 +11,10 @@ export const APP_DIRECTORY =
 
 export const recorderVersion = process.env.RECORDER_VERSION || `1.0.33`;
 
-export const RECORDER_MAC_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-x64.zip`);
-export const RECORDER_MAC_ARM64_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-arm64.zip`);
-export const RECORDER_LINUX_BUILd = url.resolve(process.env.DOWNLOADS_REPO_URL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-linux.zip`);
+const repoDownloadURL = "https://github.com/crusher-dev/crusher-debug-downloads/"
+export const RECORDER_MAC_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL || repoDownloadURL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-x64.zip`);
+export const RECORDER_MAC_ARM64_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL || repoDownloadURL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-arm64.zip`);
+export const RECORDER_LINUX_BUILd = url.resolve(process.env.DOWNLOADS_REPO_URL || repoDownloadURL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-linux.zip`);
 
 export const CLOUDFLARED_URL = {
   MAC: "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz",

--- a/packages/cli/src/module/cloudflare.ts
+++ b/packages/cli/src/module/cloudflare.ts
@@ -1,5 +1,5 @@
 import { downloadFile } from "../utils/common";
-import cli from "cli-ux";
+
 import { resolveBackendServerUrl, resolvePathToAppDirectory } from "../utils/utils";
 import { execSync } from "child_process";
 import path from "path";
@@ -11,10 +11,12 @@ import { CLOUDFLARED_URL } from "../constants";
 
 var { spawn, exec } = require("child_process");
 const fs = require("fs");
+const cliProgress = require('cli-progress');
 
 async function installNSetupOnMac() {
   const recorderZipPath = resolvePathToAppDirectory(`cloudflare.tgz`);
-  const bar = cli.progress({
+  
+  const bar = new cliProgress.SingleBar({
     format: `Downloading cloudflare tunnel {percentage}%`,
   });
 
@@ -34,7 +36,7 @@ async function installNSetupOnMac() {
 
 async function installLinuxBuild() {
   const recorderZipPath = resolvePathToAppDirectory(`bin/cloudflared`);
-  const bar = cli.progress({
+  const bar = new cliProgress.SingleBar({
     format: `Downloading cloudflare tunnel {percentage}%`,
   });
 

--- a/packages/cli/src/utils/apiUtils.ts
+++ b/packages/cli/src/utils/apiUtils.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { cli } from "cli-ux";
 import { getUserInfo } from "../state/userInfo";
 import { getLoggedInUser } from "../utils/index";
 import {
@@ -156,7 +155,7 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
     const projectConfig = getProjectConfig();
     _projectId = projectConfig.project;
   }
-  await cli.action.start("Running tests now");
+  await console.log("Running tests now");
 
   try {
     const context = getContextEnvVariables();
@@ -182,12 +181,12 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
       }
     );
 
-    await cli.action.stop();
+    console.log("");
 
     const buildInfo = res.data.buildInfo;
     const buildId = buildInfo.buildId;
 
-    await cli.action.start("Waiting for tests to finish");
+    await console.log("Waiting for tests to finish");
     // sleep for 20 seconds
     await new Promise((resolve) => {
       // create a poll to check if tests are done
@@ -210,12 +209,12 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
           buildInfo.status === "MANUAL_REVIEW_REQUIRED"
         ) {
           clearInterval(poll);
-          await cli.action.stop(
+          console.log(
             buildInfo.status === "PASSED"
               ? `Build passed in ${parseInt(buildInfo.duration)}s`
               : `Build failed in ${parseInt(buildInfo.duration)}s`
           );
-          await cli.log(
+          await console.log(
             "View build report at " +
               resolveFrontendServerUrl(`/app/build/${buildId}`)
           );
@@ -225,7 +224,7 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
     });
   } catch (err: any) {
     console.error(err);
-    await cli.action.stop(err.message);
+    console.error(err.message);
   }
 };
 

--- a/packages/cli/src/utils/common.ts
+++ b/packages/cli/src/utils/common.ts
@@ -1,7 +1,5 @@
 import axios from "axios";
-import { resolve } from "dns";
 import * as fs from "fs";
-import cli from "cli-ux";
 import * as pathModule from "path";
 
 export const downloadFile = (url, path, bar): Promise<string> => {

--- a/packages/cli/src/utils/hooks.ts
+++ b/packages/cli/src/utils/hooks.ts
@@ -6,9 +6,12 @@ import {
   resolveFrontendServerUrl,
 } from "../utils/utils";
 import axios from "axios";
-import cli from "cli-ux";
 import chalk from "chalk";
 import { isUserLoggedIn } from ".";
+const open = require('open');
+
+import ora from 'ora';
+
 
 /*
     Crusher secret invite code. Don't share it with anyone🤫
@@ -19,23 +22,24 @@ const secretInviteCode = "crush"
   Remove this after beta
 */
 const checkForDiscord = async()=>{
+
   const isCodeInCommandLine = process.argv.some((e)=>{
     return e.includes("--code=") && !["help", "--help", "-h"].includes(e)
   })
-  const hasLoginFlag = process.argv.some((e) => e.includes("--login"));
+  const hasLoginFlag = process.argv.some((e) => e.includes("login"));
 
 
   if(isUserLoggedIn() || isCodeInCommandLine) return;
 
   if(!isCodeInCommandLine && !hasLoginFlag){
-    await cli.log(chalk.green(`New to crusher?`))
+    await console.log(chalk.green(`New to crusher?`))
 
-    await cli.log(`Get access code - ${chalk.green("https://discord.gg/dHZkSNXQrg")}`)
-  await cli.log(`1.) Get access code on home screen`)
-  await cli.log(`2.) Run command with access code`)
+    await console.log(`Get access code - ${chalk.green("https://discord.gg/dHZkSNXQrg")}`)
+    await console.log(`1.) Get access code on home screen`)
+    await console.log(`2.) Run command with access code`)
 
-    await cli.log(`\n${chalk.yellow('Already have an account?')}
-    run npx crusher-cli --login \n`)
+    await console.log(`\n${chalk.yellow('Already have an account?')}
+    run npx crusher-cli login \n`)
 
   process.exit(0)
   }
@@ -63,14 +67,14 @@ const waitForUserLogin = async (): Promise<string> => {
     });
   const loginUrl = resolveFrontendServerUrl(`/login_sucessful?lK=${loginKey}&inviteCode=${discordCode}`);
 
-  await cli.log(
+  await console.log(
     "Login or create an account to create/sync tests⚡⚡. Opening a browser to sync test.\nOr open this link:"
   );
-  await cli.log(`${loginUrl} \n`);
-  await cli.action.start("Waiting for login");
+  await console.log(`${loginUrl} \n`);
 
-  await cli
-    .open(loginUrl)
+  const spinner = ora('Waiting for login').start();
+
+  await open(loginUrl)
     .catch((err) => {
       console.error(err);
     });
@@ -87,9 +91,9 @@ const waitForUserLogin = async (): Promise<string> => {
     }, 5000);
   });
 
-  await cli.action.stop();
+  spinner.stop()
 
-  await cli.log("\nLogin completed! Let's ship high quality software fast⚡⚡");
+  await console.log("\nLogin completed! Let's ship high quality software fast⚡⚡");
   return token as string;
 };
 

--- a/packages/cli/src/utils/projectConfig.ts
+++ b/packages/cli/src/utils/projectConfig.ts
@@ -64,7 +64,7 @@ export const getProjectConfig = (verbose: boolean = true) => {
 
   if(!hasLoggedProjectConfig) {
     hasLoggedProjectConfig = true;
-    console.log(chalk.green("Using project config: ") + configPath);
+    console.log(chalk.green("Using config: ") + configPath);
   }
   hasLoggedProjectConfig = true;
   if(configPath.endsWith(".js")) { const requireOriginal = eval("require"); const config = requireOriginal(configPath); return config; }

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -25,7 +25,7 @@ if(process.env.DOWNLOADS_REPO_URL) {
 
 module.exports = {
   mode: "production",
-  entry: glob.sync("./src/bin/*.ts").reduce(function (obj, el) {
+  entry: glob.sync("./src/**/*.ts").reduce(function (obj, el) {
     obj[el.replace(".ts", "")] = {
       import: el,
       dependOn: "./src/shared",

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -3,6 +3,8 @@ const glob = require("glob");
 const webpack = require("webpack");
 const { FixSharedOutputPlugin } = require("./webpack/plugins/fixShardOutput");
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+var WebpackBundleSizeAnalyzerPlugin = require('webpack-bundle-size-analyzer').WebpackBundleSizeAnalyzerPlugin;
+const StatoscopeWebpackPlugin = require('@statoscope/webpack-plugin').default;
 
 console.log( glob.sync("./src/**/*.ts").reduce(function (obj, el) {
   obj[el.replace(".ts", "")] = {
@@ -27,11 +29,10 @@ module.exports = {
   mode: "production",
   entry: glob.sync("./src/**/*.ts").reduce(function (obj, el) {
     obj[el.replace(".ts", "")] = {
-      import: el,
-      dependOn: "./src/shared",
+      import: el
     };
     return obj;
-  }, {"./src/shared": "cli-ux"}),
+  }, {}),
   node: {
     __dirname: false,
   },
@@ -57,8 +58,10 @@ module.exports = {
     new webpack.DefinePlugin({
       ...environmentVariables
     }),
-    new FixSharedOutputPlugin(),
-    // new BundleAnalyzerPlugin()
+    // new StatoscopeWebpackPlugin()
+    // new FixSharedOutputPlugin(),
+    // new BundleAnalyzerPlugin({generateStatsFile: true}),
+    // new WebpackBundleSizeAnalyzerPlugin('./reports/plain-report.txt')
   ],
   optimization: {
     splitChunks: {

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const glob = require("glob");
 const webpack = require("webpack");
 const { FixSharedOutputPlugin } = require("./webpack/plugins/fixShardOutput");
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 console.log( glob.sync("./src/**/*.ts").reduce(function (obj, el) {
   obj[el.replace(".ts", "")] = {
@@ -24,7 +25,7 @@ if(process.env.DOWNLOADS_REPO_URL) {
 
 module.exports = {
   mode: "production",
-  entry: glob.sync("./src/**/*.ts").reduce(function (obj, el) {
+  entry: glob.sync("./src/bin/*.ts").reduce(function (obj, el) {
     obj[el.replace(".ts", "")] = {
       import: el,
       dependOn: "./src/shared",
@@ -50,7 +51,6 @@ module.exports = {
   output: {
     filename: "[name].js",
     path: path.resolve(__dirname, "../../output/crusher-cli"),
-    libraryTarget: "commonjs-module",
   },
   plugins: [
     new webpack.BannerPlugin({ banner: "#!/usr/bin/env node", raw: true }),
@@ -58,5 +58,18 @@ module.exports = {
       ...environmentVariables
     }),
     new FixSharedOutputPlugin(),
+    // new BundleAnalyzerPlugin()
   ],
+  optimization: {
+    splitChunks: {
+        cacheGroups: {
+            vendor: {
+                test: /[\\/]node_modules[\\/]/,
+                name: 'vendors',
+                enforce: true,
+                chunks: 'all'
+            }
+        }
+    }
+  }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,10 @@ importers:
       typescript: ^4.1.3
       uuid: ^8.3.2
       webpack: 5.73.0
+      webpack-bundle-analyzer: ^4.6.1
       webpack-cli: ^4.10.0
+    dependencies:
+      webpack-bundle-analyzer: 4.6.1
     devDependencies:
       '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.16.7
       '@babel/preset-env': 7.18.9_@babel+core@7.16.7
@@ -139,7 +142,7 @@ importers:
       typescript: 4.3.5
       uuid: 8.3.2
       webpack: 5.73.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_webpack@5.73.0
+      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   packages/code-generator:
     specifiers:
@@ -4546,7 +4549,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/node': 17.0.38
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
       graceful-fs: 4.2.9
@@ -5566,7 +5569,6 @@ packages:
 
   /@polka/url/1.0.0-next.15:
     resolution: {integrity: sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==}
-    dev: true
 
   /@popperjs/core/2.9.2:
     resolution: {integrity: sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==}
@@ -9672,7 +9674,6 @@ packages:
     dependencies:
       '@types/eslint': 7.2.14
       '@types/estree': 0.0.51
-    dev: true
 
   /@types/eslint/7.2.14:
     resolution: {integrity: sha512-pESyhSbUOskqrGcaN+bCXIQDyT5zTaRWfj5ZjjSlMatgGjIn3QQPfocAu4WSabUR7CGyLZ2CQaZyISOEX7/saw==}
@@ -10388,7 +10389,6 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-    dev: true
 
   /@webassemblyjs/ast/1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -10402,7 +10402,6 @@ packages:
 
   /@webassemblyjs/floating-point-hex-parser/1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
-    dev: true
 
   /@webassemblyjs/floating-point-hex-parser/1.9.0:
     resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
@@ -10412,7 +10411,6 @@ packages:
 
   /@webassemblyjs/helper-api-error/1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
-    dev: true
 
   /@webassemblyjs/helper-api-error/1.9.0:
     resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
@@ -10422,7 +10420,6 @@ packages:
 
   /@webassemblyjs/helper-buffer/1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
-    dev: true
 
   /@webassemblyjs/helper-buffer/1.9.0:
     resolution: {integrity: sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==}
@@ -10453,14 +10450,12 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.1
       '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.0:
     resolution: {integrity: sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==}
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
-    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.9.0:
     resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
@@ -10480,7 +10475,6 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
-    dev: true
 
   /@webassemblyjs/helper-wasm-section/1.9.0:
     resolution: {integrity: sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==}
@@ -10499,7 +10493,6 @@ packages:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
-    dev: true
 
   /@webassemblyjs/ieee754/1.9.0:
     resolution: {integrity: sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==}
@@ -10515,7 +10508,6 @@ packages:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/leb128/1.9.0:
     resolution: {integrity: sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==}
@@ -10527,7 +10519,6 @@ packages:
 
   /@webassemblyjs/utf8/1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
-    dev: true
 
   /@webassemblyjs/utf8/1.9.0:
     resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
@@ -10555,7 +10546,6 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
       '@webassemblyjs/wast-printer': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-edit/1.9.0:
     resolution: {integrity: sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==}
@@ -10586,7 +10576,6 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-gen/1.9.0:
     resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
@@ -10612,7 +10601,6 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-opt/1.9.0:
     resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
@@ -10641,7 +10629,6 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-parser/1.9.0:
     resolution: {integrity: sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==}
@@ -10674,7 +10661,6 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/wast-printer/1.9.0:
     resolution: {integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==}
@@ -10700,8 +10686,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.73.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_webpack@5.73.0
-    dev: true
+      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   /@webpack-cli/configtest/1.2.0_aa73yiufjzrs5dnjm4asji72by:
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
@@ -10736,7 +10721,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_ptzbz4bao7we2onwdcwwuffqhy
+      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   /@webpack-cli/serve/1.5.1_r5jz6ab5h5z5ui7vgheqnt6cae:
     resolution: {integrity: sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==}
@@ -10760,7 +10745,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_webpack@5.39.1
+      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   /@webpack-cli/serve/1.7.0_xcsigq56yu4htn6anmcckynncu:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -10879,7 +10864,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.7.1
-    dev: true
 
   /acorn-jsx/5.3.1_acorn@7.4.1:
     resolution: {integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==}
@@ -10907,7 +10891,6 @@ packages:
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
   /acorn/3.3.0:
     resolution: {integrity: sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==}
@@ -11011,8 +10994,10 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -11260,10 +11245,10 @@ packages:
     resolution: {integrity: sha512-Bxn8U3KIVthgBVXN//hgF6gD+LPHwXl/pcoKxVR64JlyMKdcrmpFssahO71O07RLEZnXzcwBXh4qIjK74xJ/bw==}
     engines: {node: '>=14.0.0'}
     dependencies:
+      7zip-bin: 5.1.1
       '@develar/schema-utils': 2.6.5
       '@electron/universal': 1.2.1
       '@malept/flatpak-bundler': 0.4.0
-      7zip-bin: 5.1.1
       async-exit-hook: 2.0.1
       bluebird-lst: 1.0.9
       builder-util: 23.3.0
@@ -12847,9 +12832,9 @@ packages:
   /builder-util/23.3.0:
     resolution: {integrity: sha512-m7RRd21N2yrnuGFd+ZqOY0ryeqWmBslDKmGDVz0wETqoEEqpiJsF3CGlsb6MRN2EQKDubvE5e+lBf8ATt06fnA==}
     dependencies:
+      7zip-bin: 5.1.1
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
-      7zip-bin: 5.1.1
       app-builder-bin: 4.0.0
       bluebird-lst: 1.0.9
       builder-util-runtime: 9.0.3
@@ -14041,8 +14026,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.0.0
@@ -15922,7 +15907,6 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       tapable: 2.2.0
-    dev: true
 
   /enhanced-resolve/5.8.2:
     resolution: {integrity: sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==}
@@ -16012,7 +15996,6 @@ packages:
 
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
-    dev: true
 
   /es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
@@ -18303,7 +18286,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       duplexer: 0.1.2
-    dev: true
 
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -19931,7 +19913,7 @@ packages:
       '@jest/core': 27.4.7
       '@jest/test-result': 27.4.6
       '@jest/types': 27.5.1
-      chalk: 4.1.1
+      chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.9
       import-local: 3.0.2
@@ -23865,7 +23847,6 @@ packages:
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
-    dev: true
 
   /openurl/1.1.1:
     resolution: {integrity: sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==}
@@ -28572,7 +28553,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scroll-smooth/1.1.0:
@@ -29040,7 +29021,6 @@ packages:
       '@polka/url': 1.0.0-next.15
       mime: 2.5.2
       totalist: 1.1.0
-    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -30441,7 +30421,6 @@ packages:
       source-map: 0.6.1
       terser: 5.13.1
       webpack: 5.73.0_webpack-cli@4.10.0
-    dev: true
 
   /terser-webpack-plugin/5.3.1_zjtckeea76d3oit4tw4tcptpni:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -30640,7 +30619,6 @@ packages:
   /totalist/1.1.0:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
     engines: {node: '>=6'}
-    dev: true
 
   /tough-cookie/4.0.0:
     resolution: {integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==}
@@ -32007,7 +31985,6 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.9
-    dev: true
 
   /wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
@@ -32051,6 +32028,24 @@ packages:
       - utf-8-validate
     dev: true
 
+  /webpack-bundle-analyzer/4.6.1:
+    resolution: {integrity: sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+    dependencies:
+      acorn: 8.7.1
+      acorn-walk: 8.2.0
+      chalk: 4.1.2
+      commander: 7.2.0
+      gzip-size: 6.0.0
+      lodash: 4.17.21
+      opener: 1.5.2
+      sirv: 1.0.12
+      ws: 7.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   /webpack-cli/3.3.12_webpack@5.39.1:
     resolution: {integrity: sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==}
     engines: {node: '>=6.11.5'}
@@ -32070,6 +32065,41 @@ packages:
       v8-compile-cache: 2.3.0
       webpack: 5.39.1_6efkfduqsrgl4zjzwkpjn3ng7u
       yargs: 13.3.2
+
+  /webpack-cli/4.10.0_bco76sj2s6hhm5n6qzmeypcd64:
+    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@webpack-cli/generators': '*'
+      '@webpack-cli/migrate': '*'
+      webpack: 4.x.x || 5.x.x
+      webpack-bundle-analyzer: '*'
+      webpack-dev-server: '*'
+    peerDependenciesMeta:
+      '@webpack-cli/generators':
+        optional: true
+      '@webpack-cli/migrate':
+        optional: true
+      webpack-bundle-analyzer:
+        optional: true
+      webpack-dev-server:
+        optional: true
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.3
+      '@webpack-cli/configtest': 1.2.0_77l47gmqkrqiei5z7sbwz5iaj4
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_webpack-cli@4.10.0
+      colorette: 2.0.19
+      commander: 7.2.0
+      cross-spawn: 7.0.3
+      fastest-levenshtein: 1.0.12
+      import-local: 3.0.2
+      interpret: 2.2.0
+      rechoir: 0.7.0
+      webpack: 5.73.0_webpack-cli@4.10.0
+      webpack-bundle-analyzer: 4.6.1
+      webpack-merge: 5.8.0
 
   /webpack-cli/4.10.0_ptzbz4bao7we2onwdcwwuffqhy:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
@@ -32173,41 +32203,6 @@ packages:
       rechoir: 0.7.0
       webpack: 5.39.1_webpack-cli@4.10.0
       webpack-merge: 5.8.0
-
-  /webpack-cli/4.10.0_webpack@5.73.0:
-    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      '@webpack-cli/generators': '*'
-      '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x
-      webpack-bundle-analyzer: '*'
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      '@webpack-cli/generators':
-        optional: true
-      '@webpack-cli/migrate':
-        optional: true
-      webpack-bundle-analyzer:
-        optional: true
-      webpack-dev-server:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.3
-      '@webpack-cli/configtest': 1.2.0_77l47gmqkrqiei5z7sbwz5iaj4
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
-      '@webpack-cli/serve': 1.7.0_webpack-cli@4.10.0
-      colorette: 2.0.19
-      commander: 7.2.0
-      cross-spawn: 7.0.3
-      fastest-levenshtein: 1.0.12
-      import-local: 3.0.2
-      interpret: 2.2.0
-      rechoir: 0.7.0
-      webpack: 5.73.0_webpack-cli@4.10.0
-      webpack-merge: 5.8.0
-    dev: true
 
   /webpack-cli/4.7.2_ptzbz4bao7we2onwdcwwuffqhy:
     resolution: {integrity: sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==}
@@ -32549,7 +32544,6 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: true
 
   /webpack-virtual-modules/0.2.2:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
@@ -32910,13 +32904,12 @@ packages:
       tapable: 2.2.0
       terser-webpack-plugin: 5.3.1_webpack@5.73.0
       watchpack: 2.4.0
-      webpack-cli: 4.10.0_webpack@5.73.0
+      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,7 @@ importers:
       '@commitlint/cli': ^13.1.0
       '@commitlint/config-conventional': ^13.1.0
       '@commitlint/prompt': ^13.1.0
+      '@statoscope/webpack-plugin': ^5.24.0
       '@types/fs-extra': ^9.0.13
       '@types/jest': ^27.0.1
       '@types/node': ^16.9.4
@@ -72,6 +73,7 @@ importers:
       axios-mock-adapter: ^1.20.0
       boxen: ^5.1.2
       chalk: ^4.0.0
+      cli-progress: ^3.11.2
       cli-ux: ^6.0.9
       codecov: ^3.1.0
       command-exists: ^1.2.9
@@ -83,12 +85,14 @@ importers:
       glob: ^7.2.0
       husky: ^7.0.2
       ini: ^3.0.0
-      inquirer: ^6.2.0
+      inquirer: ^6.1.0
       jest: ^27.2.0
       jsonfile: ^6.1.0
       lint-staged: ^11.1.2
       localtunnel: ^2.0.2
       nock: ^13.2.4
+      open: ^8.4.0
+      ora: ^5.0.0
       prettier: ^2.4.1
       replace-json-property: ^1.4.1
       semver: ^7.3.7
@@ -99,9 +103,10 @@ importers:
       uuid: ^8.3.2
       webpack: 5.73.0
       webpack-bundle-analyzer: ^4.6.1
+      webpack-bundle-size-analyzer: ^3.1.0
       webpack-cli: ^4.10.0
     dependencies:
-      webpack-bundle-analyzer: 4.6.1
+      ora: 5.4.1
     devDependencies:
       '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.16.7
       '@babel/preset-env': 7.18.9_@babel+core@7.16.7
@@ -109,6 +114,7 @@ importers:
       '@commitlint/cli': 13.2.1
       '@commitlint/config-conventional': 13.2.0
       '@commitlint/prompt': 13.2.1
+      '@statoscope/webpack-plugin': 5.24.0_webpack@5.73.0
       '@types/fs-extra': 9.0.13
       '@types/jest': 27.4.0
       '@types/node': 16.11.45
@@ -116,6 +122,7 @@ importers:
       axios-mock-adapter: 1.21.1_axios@0.25.0
       boxen: 5.1.2
       chalk: 4.1.1
+      cli-progress: 3.11.2
       cli-ux: 6.0.9
       codecov: 3.8.3
       command-exists: 1.2.9
@@ -133,6 +140,7 @@ importers:
       lint-staged: 11.2.6
       localtunnel: 2.0.2
       nock: 13.2.9
+      open: 8.4.0
       prettier: 2.7.1
       replace-json-property: 1.8.0
       semver: 7.3.7
@@ -142,6 +150,8 @@ importers:
       typescript: 4.3.5
       uuid: 8.3.2
       webpack: 5.73.0_webpack-cli@4.10.0
+      webpack-bundle-analyzer: 4.6.1
+      webpack-bundle-size-analyzer: 3.1.0
       webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   packages/code-generator:
@@ -3850,6 +3860,16 @@ packages:
     resolution: {integrity: sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==}
     engines: {node: '>=10.0.0'}
 
+  /@discoveryjs/json-ext/0.5.7:
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
+    dev: true
+
+  /@discoveryjs/natural-compare/1.0.0:
+    resolution: {integrity: sha512-Pq35vJMxLZq4whZhyaMGO/89mmFee2+6NojaXD2bNo+7CxI6P7C1tncgQ0CM60+WueRMr8uFDKSX/8KitImCQg==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+    dev: true
+
   /@electron/get/1.12.4:
     resolution: {integrity: sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==}
     engines: {node: '>=8.6'}
@@ -4594,7 +4614,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/node': 17.0.38
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
       graceful-fs: 4.2.9
@@ -5569,6 +5589,7 @@ packages:
 
   /@polka/url/1.0.0-next.15:
     resolution: {integrity: sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==}
+    dev: true
 
   /@popperjs/core/2.9.2:
     resolution: {integrity: sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==}
@@ -7619,6 +7640,128 @@ packages:
     dependencies:
       '@sinonjs/commons': 1.8.3
 
+  /@statoscope/extensions/5.14.1:
+    resolution: {integrity: sha512-5O31566+bOkkdYFH81mGGBTh0YcU0zoYurTrsK5uZfpNY87ZCPpptrszX8npTRHNsxbjBBNt7vAwImJyYdhzLw==}
+    dev: true
+
+  /@statoscope/helpers/5.24.0:
+    resolution: {integrity: sha512-PhCynDA+FHB1DuuHlMeVnETRRDfgKrQTGey2jhBdHzd/Gae/GuwDcnFxiRVMIA97UQM8EwyE/hc0sF6dpPXd9w==}
+    dependencies:
+      '@types/archy': 0.0.32
+      '@types/semver': 7.3.12
+      archy: 1.0.0
+      jora: 1.0.0-beta.7
+      semver: 7.3.7
+    dev: true
+
+  /@statoscope/report-writer/5.22.0:
+    resolution: {integrity: sha512-oEIlfsMSwBM8PcHnHDwhgMz5fyDgu10oAVFwuQSJFBUXMwaZ/46ewr1kfAcUNc8CkOIolhO6EIo/e0ZjcVCR1g==}
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+    dev: true
+
+  /@statoscope/stats-extension-compressed/5.24.0:
+    resolution: {integrity: sha512-QRgTY7wnJhB5BjV2OHt2e3E8rLi+53LEJ2q7KZDjRMNZNGY6G1LPIuHTCAUlcLNxDbaeATqkioTVRyf2v9SjPQ==}
+    dependencies:
+      '@statoscope/helpers': 5.24.0
+      gzip-size: 6.0.0
+    dev: true
+
+  /@statoscope/stats-extension-custom-reports/5.24.0:
+    resolution: {integrity: sha512-n20dL3WYrwla8eCYNtHY0AdcBuyHiaW1F2gQBsJqV3PJzIYBijo/f1dHl2p8hzVDQmJ/QYWNwsbTvr1GQGdseg==}
+    dependencies:
+      '@statoscope/extensions': 5.14.1
+      '@statoscope/helpers': 5.24.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/types': 5.22.0
+    dev: true
+
+  /@statoscope/stats-extension-package-info/5.24.0:
+    resolution: {integrity: sha512-L7UtVb5CwG2dMZdVrGjok4+0ryEASO1rr8Kf/QzcQNIHb8mG5VSYRFBlcFfvvC/PNKafxoexbwhiSGZEtggwqw==}
+    dependencies:
+      '@statoscope/helpers': 5.24.0
+    dev: true
+
+  /@statoscope/stats-extension-stats-validation-result/5.24.0:
+    resolution: {integrity: sha512-++8hX2cb0CpIM+gqLwIl9N/ISJHTKtrQXwsl9CSlds3K4D49BwC2cULlvhGdjVRMf7U1RI0COL9dj79K7iK5Ig==}
+    dependencies:
+      '@statoscope/extensions': 5.14.1
+      '@statoscope/helpers': 5.24.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/types': 5.22.0
+    dev: true
+
+  /@statoscope/stats/5.14.1:
+    resolution: {integrity: sha512-Kz7kCKuT6DXaqAPfyTwp27xHMDUna9o6UlRSQXXBZ8Yyk7eYYvTNw+5ffRyqivL9IOzD7FQYDQ6VUBHh0UfyDw==}
+    dev: true
+
+  /@statoscope/types/5.22.0:
+    resolution: {integrity: sha512-FHgunU7M95v7c71pvQ2nr8bWy1QcTDOHSnkoFQErORH9RmxlK9oRkoWrO8BJpnxa55m/9ZHjFVmpLF4SsVGHoA==}
+    dependencies:
+      '@statoscope/stats': 5.14.1
+    dev: true
+
+  /@statoscope/webpack-model/5.24.0:
+    resolution: {integrity: sha512-6XHhTbA4Vw8LKUGLuRvsNUUgiiGAvqciUMQRjovf2xNRT2a3rCP7L3QKOntEvIBcKzNGuQ0T+L5sKF8pqiI3mA==}
+    dependencies:
+      '@statoscope/extensions': 5.14.1
+      '@statoscope/helpers': 5.24.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-compressed': 5.24.0
+      '@statoscope/stats-extension-custom-reports': 5.24.0
+      '@statoscope/stats-extension-package-info': 5.24.0
+      '@statoscope/stats-extension-stats-validation-result': 5.24.0
+      '@statoscope/types': 5.22.0
+      md5: 2.3.0
+    dev: true
+
+  /@statoscope/webpack-plugin/5.24.0_webpack@5.73.0:
+    resolution: {integrity: sha512-8GX0ULmvwZRAqQClLMdzV1L/Y9PBJZTwBTXiiKzU4+vypRiI7VA+fz9aZ2XGWErVonXbrIvclj2IAQMbz/z2YQ==}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@statoscope/report-writer': 5.22.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-compressed': 5.24.0
+      '@statoscope/stats-extension-custom-reports': 5.24.0
+      '@statoscope/types': 5.22.0
+      '@statoscope/webpack-model': 5.24.0
+      '@statoscope/webpack-stats-extension-compressed': 5.24.0_webpack@5.73.0
+      '@statoscope/webpack-stats-extension-package-info': 5.24.0_webpack@5.73.0
+      '@statoscope/webpack-ui': 5.24.0
+      open: 8.4.0
+      webpack: 5.73.0_webpack-cli@4.10.0
+    dev: true
+
+  /@statoscope/webpack-stats-extension-compressed/5.24.0_webpack@5.73.0:
+    resolution: {integrity: sha512-yJyYo/TC393MZcA/txnd/37WubSdGNpVAncFlifVtJoGgsD9GrqltN8aUiaVPBDy/r4N4qP9+8T6OQ/Ha4J4DA==}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-compressed': 5.24.0
+      '@statoscope/webpack-model': 5.24.0
+      webpack: 5.73.0_webpack-cli@4.10.0
+    dev: true
+
+  /@statoscope/webpack-stats-extension-package-info/5.24.0_webpack@5.73.0:
+    resolution: {integrity: sha512-AXtYSbvyyFdgn1H/bnE2gu0oEhKBiHbeZA/gCJM+hEWOwGWnz61+qiPxYj2QnOnXN8XmjHho3jf0Gd4eW3dJfw==}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-package-info': 5.24.0
+      '@statoscope/webpack-model': 5.24.0
+      webpack: 5.73.0_webpack-cli@4.10.0
+    dev: true
+
+  /@statoscope/webpack-ui/5.24.0:
+    resolution: {integrity: sha512-tqNH1O7WE8dVa2WknmmM4j7mYD6mna3TKRLRYmiAwg6W/RICVAxXwZy1v9uKN9+pfa6By0hI3mWiYS7V1seh2w==}
+    dependencies:
+      '@statoscope/types': 5.22.0
+    dev: true
+
   /@stitches/react/1.2.8_react@17.0.2:
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
     peerDependencies:
@@ -9543,6 +9686,10 @@ packages:
       '@types/glob': 7.1.3
     dev: false
 
+  /@types/archy/0.0.32:
+    resolution: {integrity: sha512-5ZZ5+YGmUE01yejiXsKnTcvhakMZ2UllZlMsQni53Doc1JWhe21ia8VntRoRD6fAEWw08JBh/z9qQHJ+//MrIg==}
+    dev: true
+
   /@types/aria-query/4.2.2:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
     dev: false
@@ -9674,6 +9821,7 @@ packages:
     dependencies:
       '@types/eslint': 7.2.14
       '@types/estree': 0.0.51
+    dev: true
 
   /@types/eslint/7.2.14:
     resolution: {integrity: sha512-pESyhSbUOskqrGcaN+bCXIQDyT5zTaRWfj5ZjjSlMatgGjIn3QQPfocAu4WSabUR7CGyLZ2CQaZyISOEX7/saw==}
@@ -10106,6 +10254,10 @@ packages:
   /@types/scheduler/0.16.1:
     resolution: {integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==}
 
+  /@types/semver/7.3.12:
+    resolution: {integrity: sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==}
+    dev: true
+
   /@types/semver/7.3.9:
     resolution: {integrity: sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==}
     dev: false
@@ -10389,6 +10541,7 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+    dev: true
 
   /@webassemblyjs/ast/1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -10402,6 +10555,7 @@ packages:
 
   /@webassemblyjs/floating-point-hex-parser/1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
+    dev: true
 
   /@webassemblyjs/floating-point-hex-parser/1.9.0:
     resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
@@ -10411,6 +10565,7 @@ packages:
 
   /@webassemblyjs/helper-api-error/1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
+    dev: true
 
   /@webassemblyjs/helper-api-error/1.9.0:
     resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
@@ -10420,6 +10575,7 @@ packages:
 
   /@webassemblyjs/helper-buffer/1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
+    dev: true
 
   /@webassemblyjs/helper-buffer/1.9.0:
     resolution: {integrity: sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==}
@@ -10450,12 +10606,14 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.1
       '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.0:
     resolution: {integrity: sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==}
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
+    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.9.0:
     resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
@@ -10475,6 +10633,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
+    dev: true
 
   /@webassemblyjs/helper-wasm-section/1.9.0:
     resolution: {integrity: sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==}
@@ -10493,6 +10652,7 @@ packages:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
+    dev: true
 
   /@webassemblyjs/ieee754/1.9.0:
     resolution: {integrity: sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==}
@@ -10508,6 +10668,7 @@ packages:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/leb128/1.9.0:
     resolution: {integrity: sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==}
@@ -10519,6 +10680,7 @@ packages:
 
   /@webassemblyjs/utf8/1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
+    dev: true
 
   /@webassemblyjs/utf8/1.9.0:
     resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
@@ -10546,6 +10708,7 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
       '@webassemblyjs/wast-printer': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-edit/1.9.0:
     resolution: {integrity: sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==}
@@ -10576,6 +10739,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-gen/1.9.0:
     resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
@@ -10601,6 +10765,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-opt/1.9.0:
     resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
@@ -10629,6 +10794,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-parser/1.9.0:
     resolution: {integrity: sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==}
@@ -10661,6 +10827,7 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/wast-printer/1.9.0:
     resolution: {integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==}
@@ -10687,6 +10854,7 @@ packages:
     dependencies:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+    dev: true
 
   /@webpack-cli/configtest/1.2.0_aa73yiufjzrs5dnjm4asji72by:
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
@@ -10721,7 +10889,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+      webpack-cli: 4.10.0_ptzbz4bao7we2onwdcwwuffqhy
 
   /@webpack-cli/serve/1.5.1_r5jz6ab5h5z5ui7vgheqnt6cae:
     resolution: {integrity: sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==}
@@ -10745,7 +10913,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+      webpack-cli: 4.10.0_webpack@5.39.1
 
   /@webpack-cli/serve/1.7.0_xcsigq56yu4htn6anmcckynncu:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -10864,6 +11032,7 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.7.1
+    dev: true
 
   /acorn-jsx/5.3.1_acorn@7.4.1:
     resolution: {integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==}
@@ -10994,10 +11163,8 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -11245,10 +11412,10 @@ packages:
     resolution: {integrity: sha512-Bxn8U3KIVthgBVXN//hgF6gD+LPHwXl/pcoKxVR64JlyMKdcrmpFssahO71O07RLEZnXzcwBXh4qIjK74xJ/bw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      7zip-bin: 5.1.1
       '@develar/schema-utils': 2.6.5
       '@electron/universal': 1.2.1
       '@malept/flatpak-bundler': 0.4.0
+      7zip-bin: 5.1.1
       async-exit-hook: 2.0.1
       bluebird-lst: 1.0.9
       builder-util: 23.3.0
@@ -12832,9 +12999,9 @@ packages:
   /builder-util/23.3.0:
     resolution: {integrity: sha512-m7RRd21N2yrnuGFd+ZqOY0ryeqWmBslDKmGDVz0wETqoEEqpiJsF3CGlsb6MRN2EQKDubvE5e+lBf8ATt06fnA==}
     dependencies:
-      7zip-bin: 5.1.1
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
+      7zip-bin: 5.1.1
       app-builder-bin: 4.0.0
       bluebird-lst: 1.0.9
       builder-util-runtime: 9.0.3
@@ -13234,7 +13401,6 @@ packages:
 
   /charenc/0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-    dev: false
 
   /charm/0.1.2:
     resolution: {integrity: sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==}
@@ -13458,13 +13624,17 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       restore-cursor: 3.1.0
-    dev: true
 
   /cli-progress/3.11.2:
     resolution: {integrity: sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==}
     engines: {node: '>=4'}
     dependencies:
       string-width: 4.2.3
+
+  /cli-spinners/2.7.0:
+    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
+    engines: {node: '>=6'}
+    dev: false
 
   /cli-table3/0.6.2:
     resolution: {integrity: sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==}
@@ -13598,6 +13768,11 @@ packages:
     resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
     dependencies:
       mimic-response: 1.0.1
+    dev: false
+
+  /clone/1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
     dev: false
 
   /clsx/1.1.1:
@@ -14026,8 +14201,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.0.0
@@ -14398,7 +14573,6 @@ packages:
 
   /crypt/0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
-    dev: false
 
   /crypto-browserify/3.12.0:
     resolution: {integrity: sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==}
@@ -15129,6 +15303,12 @@ packages:
     dependencies:
       execa: 1.0.0
       ip-regex: 2.1.0
+
+  /defaults/1.0.3:
+    resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
+    dependencies:
+      clone: 1.0.4
+    dev: false
 
   /defer-to-connect/1.1.3:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
@@ -15907,6 +16087,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       tapable: 2.2.0
+    dev: true
 
   /enhanced-resolve/5.8.2:
     resolution: {integrity: sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==}
@@ -15996,6 +16177,7 @@ packages:
 
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+    dev: true
 
   /es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
@@ -17161,6 +17343,11 @@ packages:
     dependencies:
       minimatch: 3.1.2
 
+  /filesize/3.6.1:
+    resolution: {integrity: sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==}
+    engines: {node: '>= 0.4.0'}
+    dev: true
+
   /filesize/6.1.0:
     resolution: {integrity: sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==}
     engines: {node: '>= 0.4.0'}
@@ -18286,6 +18473,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       duplexer: 0.1.2
+    dev: true
 
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -18818,6 +19006,10 @@ packages:
   /human-signals/2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  /humanize/0.0.9:
+    resolution: {integrity: sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q==}
+    dev: true
 
   /husky/6.0.0:
     resolution: {integrity: sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==}
@@ -19400,6 +19592,11 @@ packages:
       is-path-inside: 3.0.3
     dev: false
 
+  /is-interactive/1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+    dev: false
+
   /is-lite/0.8.1:
     resolution: {integrity: sha512-ekSwuewzOmwFnzzAOWuA5fRFPqOeTrLIL3GWT7hdVVi+oLuD+Rau8gCmkb94vH5hjXc1Q/CfIW/y/td1RrNQIg==}
     dev: false
@@ -19598,6 +19795,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       unc-path-regex: 0.1.2
+    dev: false
+
+  /is-unicode-supported/0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
     dev: false
 
   /is-url/1.2.4:
@@ -19943,7 +20145,7 @@ packages:
       '@jest/core': 27.4.7_ts-node@9.1.1
       '@jest/test-result': 27.4.6
       '@jest/types': 27.5.1
-      chalk: 4.1.1
+      chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.9
       import-local: 3.0.2
@@ -20887,6 +21089,13 @@ packages:
   /join-component/1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
     dev: false
+
+  /jora/1.0.0-beta.7:
+    resolution: {integrity: sha512-7Mq37XUPQM/fEetH8Z4iHTABWgoq64UL9mIRfssX1b0Ogns3TqbOS0UIV7gwQ3D0RshfLJzGgbbW17UyFjxSLQ==}
+    engines: {node: ^10.12.0 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      '@discoveryjs/natural-compare': 1.0.0
+    dev: true
 
   /jotai/1.4.7_taaswbfv5gpjqrwqwdhq6newyu:
     resolution: {integrity: sha512-EZFmhovnufIVoH0OAW6kuOv8RLjCX2HvHEqzwRG79l/LDeyp1BI+85vrEpR/fQmqh3jUhY4SyjhboEItd4+reQ==}
@@ -21904,6 +22113,14 @@ packages:
       chalk: 2.4.2
     dev: true
 
+  /log-symbols/4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+    dev: false
+
   /log-update/1.0.2:
     resolution: {integrity: sha512-4vSow8gbiGnwdDNrpy1dyNaXWKSCIPop0EHdE8GrnngHoJujM3QhvHUN/igsYCgPoHo7pFOezlJ61Hlln0KHyA==}
     engines: {node: '>=0.10.0'}
@@ -22180,7 +22397,6 @@ packages:
       charenc: 0.0.2
       crypt: 0.0.2
       is-buffer: 1.1.6
-    dev: false
 
   /mdast-comment-marker/2.1.0:
     resolution: {integrity: sha512-/+Cfm8A83PjkqjQDB9iYqHESGuXlriCWAwRGPJjkYmxXrF4r6saxeUlOKNrf+SogTwg9E8uyHRCFHLG6/BAAdA==}
@@ -23847,6 +24063,7 @@ packages:
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
+    dev: true
 
   /openurl/1.1.1:
     resolution: {integrity: sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==}
@@ -23892,6 +24109,21 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
+
+  /ora/5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.7.0
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+    dev: false
 
   /original/1.0.2:
     resolution: {integrity: sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==}
@@ -26666,6 +26898,8 @@ packages:
       shell-quote: 1.7.2
       strip-ansi: 6.0.0
       text-table: 0.2.0
+      typescript: 4.3.5
+      webpack: 4.44.2
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -28175,7 +28409,6 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: true
 
   /ret/0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
@@ -28553,7 +28786,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scroll-smooth/1.1.0:
@@ -29021,6 +29254,7 @@ packages:
       '@polka/url': 1.0.0-next.15
       mime: 2.5.2
       totalist: 1.1.0
+    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -30421,6 +30655,7 @@ packages:
       source-map: 0.6.1
       terser: 5.13.1
       webpack: 5.73.0_webpack-cli@4.10.0
+    dev: true
 
   /terser-webpack-plugin/5.3.1_zjtckeea76d3oit4tw4tcptpni:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -30619,6 +30854,7 @@ packages:
   /totalist/1.1.0:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
     engines: {node: '>=6'}
+    dev: true
 
   /tough-cookie/4.0.0:
     resolution: {integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==}
@@ -31217,6 +31453,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.5
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -31985,11 +32222,18 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.9
+    dev: true
 
   /wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
     dependencies:
       minimalistic-assert: 1.0.1
+
+  /wcwidth/1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+    dependencies:
+      defaults: 1.0.3
+    dev: false
 
   /web-namespaces/1.1.4:
     resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
@@ -32045,6 +32289,16 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: true
+
+  /webpack-bundle-size-analyzer/3.1.0:
+    resolution: {integrity: sha512-8WlTT6uuCxZgZYNnCB0pRGukWRGH+Owg+HsqQUe1Zexakdno1eDYO+lE7ihBo9G0aCCZCJa8JWjYr9eLYfZrBA==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      filesize: 3.6.1
+      humanize: 0.0.9
+    dev: true
 
   /webpack-cli/3.3.12_webpack@5.39.1:
     resolution: {integrity: sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==}
@@ -32100,6 +32354,7 @@ packages:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.6.1
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-cli/4.10.0_ptzbz4bao7we2onwdcwwuffqhy:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
@@ -32544,6 +32799,7 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: true
 
   /webpack-virtual-modules/0.2.2:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
@@ -32910,6 +33166,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}


### PR DESCRIPTION
- Created common bundle for all the entrypoint as we don't have multiple bin file. Earlier there were multiple entrypoint with no chunks.

Future: Further decrease by 50%
- Remove cLI-ux. It's deprecated. Use native packages. Currently it's including full fledged lodash, esprima, rxjs, etc. We don't need it.