### PR TITLE
Remove CLI UX

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,12 +17,15 @@
     "run": "ts-node src/bin/index.ts",
     "build": "webpack && PACKAGE_NAME=crusher-cli node scripts/copyPackageJson.js",
     "build:debug": "webpack && PACKAGE_NAME=crusher-debug node scripts/copyPackageJson.js",
+    "analyzer": "webpack-cli --profile --json > compilation-stats.json",
     "test": "jest"
   },
   "dependencies": {
+    "@statoscope/webpack-plugin": "^5.24.0",
     "cli-progress": "^3.11.2",
     "open": "^8.4.0",
-    "webpack-bundle-analyzer": "^4.6.1"
+    "webpack-bundle-analyzer": "^4.6.1",
+    "webpack-bundle-size-analyzer": "^3.1.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",
@@ -49,7 +52,7 @@
     "glob": "^7.2.0",
     "husky": "^7.0.2",
     "ini": "^3.0.0",
-    "inquirer": "^6.2.0",
+    "inquirer": "^9.1.0",
     "jest": "^27.2.0",
     "jsonfile": "^6.1.0",
     "lint-staged": "^11.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "cli-progress": "^3.11.2",
+    "open": "^8.4.0",
     "webpack-bundle-analyzer": "^4.6.1"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.46",
   "author": "Himanshu @himanshu-dixit",
   "repository": "https://github.com/crusherdev/CLI",
-  "main": "index.js",
+  "main": "./src/bin/index.js",
   "private": true,
   "license": "MIT",
   "bin": {
@@ -21,11 +21,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@statoscope/webpack-plugin": "^5.24.0",
-    "cli-progress": "^3.11.2",
-    "open": "^8.4.0",
-    "webpack-bundle-analyzer": "^4.6.1",
-    "webpack-bundle-size-analyzer": "^3.1.0"
+    "ora": "^5.0.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",
@@ -34,6 +30,7 @@
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
     "@commitlint/prompt": "^13.1.0",
+    "@statoscope/webpack-plugin": "^5.24.0",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.4",
@@ -41,6 +38,7 @@
     "axios-mock-adapter": "^1.20.0",
     "boxen": "^5.1.2",
     "chalk": "^4.0.0",
+    "cli-progress": "^3.11.2",
     "cli-ux": "^6.0.9",
     "codecov": "^3.1.0",
     "command-exists": "^1.2.9",
@@ -52,12 +50,13 @@
     "glob": "^7.2.0",
     "husky": "^7.0.2",
     "ini": "^3.0.0",
-    "inquirer": "^9.1.0",
+    "inquirer": "^6.1.0",
     "jest": "^27.2.0",
     "jsonfile": "^6.1.0",
     "lint-staged": "^11.1.2",
     "localtunnel": "^2.0.2",
     "nock": "^13.2.4",
+    "open": "^8.4.0",
     "prettier": "^2.4.1",
     "replace-json-property": "^1.4.1",
     "semver": "^7.3.7",
@@ -67,6 +66,8 @@
     "typescript": "^4.1.3",
     "uuid": "^8.3.2",
     "webpack": "5.73.0",
+    "webpack-bundle-analyzer": "^4.6.1",
+    "webpack-bundle-size-analyzer": "^3.1.0",
     "webpack-cli": "^4.10.0"
   }
 }

--- a/packages/cli/scripts/copyPackageJson.js
+++ b/packages/cli/scripts/copyPackageJson.js
@@ -22,6 +22,8 @@ const patchVersion = (versionStr) => {
     if (fs.existsSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"))) {
       fs.unlinkSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"));
     }
+
+    fs.writeFileSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"), JSON.stringify(packageJSON), "utf8");  
     
     fs.writeFileSync(path.resolve(__dirname, "../../../output/crusher-cli/package.json"), JSON.stringify(packageJSON), "utf8");  
   }).catch((err) => {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,8 +1,21 @@
-import { Command, program } from "commander";
-import * as packgeJSON from "../../package.json";
-import fs from "fs";
-import path from "path";
 import chalk from "chalk";
+
+import whoami from "./whoami";
+import info from "./info";
+import logout from "./logout";
+import login from "./login";
+import tunnel from "./tunnel";
+import invite from "./invite";
+import init from "./init";
+import token from "./token";
+import testCreate from "./test/create";
+import testRun from "./test/run";
+
+const CommandRegister = {
+  whoami,info, logout, login, token, tunnel, invite, init,
+  "test:create": testCreate,
+  "test:run":testRun
+}
 
 export default class CommandBase {
   constructor() {}
@@ -39,32 +52,19 @@ export default class CommandBase {
 
   async run() {
     const type = process.argv[2];
+
     if (
-      type &&
-      fs.existsSync(
-        path.resolve(
-          __dirname,
-          "../commands/",
-          `${this.getPathForType(type)}.${
-            process.env.NODE_ENV === "production" ? "js" : "ts"
-          }`
-        )
-      )
+      type
     ) {
-      //@ts-ignore
-      const requireCommand =typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
       try {
-        await (new (requireCommand(
-          path.resolve(
-            __dirname,
-            "../commands/",
-            `${this.getPathForType(type)}.${
-              process.env.NODE_ENV === "production" ? "js" : "ts"
-            }`
-          )
-        ).default)()).init();
+        const commandInstance = new CommandRegister[type]();
+        commandInstance.init()
       } catch (err) {
         if (err.message === "SIGINT") process.exit(1);
+        if(err.message.includes("not a constructor")){
+          console.log(`No such command -> ${type }. Run --help.`);
+          process.exit(1);
+        }
         console.log(chalk.red("Error:"), err.message);
         process.exit(1);
       }

--- a/packages/cli/src/commands/invite.ts
+++ b/packages/cli/src/commands/invite.ts
@@ -1,6 +1,4 @@
 import { Command } from "commander";
-import * as packgeJSON from "../../package.json";
-
 import * as inquirer from "inquirer";
 
 import { getProjectConfig } from "../utils/projectConfig";

--- a/packages/cli/src/commands/invite.ts
+++ b/packages/cli/src/commands/invite.ts
@@ -1,8 +1,9 @@
 import { Command } from "commander";
-import * as inquirer from "inquirer";
-
+import inquirer from 'inquirer';
 import { getProjectConfig } from "../utils/projectConfig";
 import { getInviteLink, inviteProjectMembers } from "../utils/apiUtils";
+import ora from 'ora';
+
 
 const program = new Command();
 program.addHelpText(
@@ -51,9 +52,10 @@ export default class CommandBase {
       },
     ]);
     console.log("\n");
-    await console.log("Preparing a cryptic invite code.");
+    const spinner = ora('Preparing a cryptic invite code').start();
+
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log("");
+    spinner.stop()
 
     if (res.method === 0) {
       const emailsRes = await inquirer.prompt([
@@ -64,12 +66,12 @@ export default class CommandBase {
         },
       ]);
       console.log("Email res is", emailsRes.emails);
+      const spinner2 = ora('Sending invites').start();
+
       await console.log("Sending invites");
-      const inviteRes = await inviteProjectMembers(
-        projectConfig.project,
-        emailsRes.emails.split(",")
-      );
-      console.log("");
+
+      spinner2.stop()
+
       console.log(
         "\nInvited your folks to use crusher!. Ask them to check there mail."
       );

--- a/packages/cli/src/commands/invite.ts
+++ b/packages/cli/src/commands/invite.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import * as packgeJSON from "../../package.json";
 
 import * as inquirer from "inquirer";
-import cli from "cli-ux";
+
 import { getProjectConfig } from "../utils/projectConfig";
 import { getInviteLink, inviteProjectMembers } from "../utils/apiUtils";
 
@@ -53,9 +53,9 @@ export default class CommandBase {
       },
     ]);
     console.log("\n");
-    await cli.action.start("Preparing a cryptic invite code.");
+    await console.log("Preparing a cryptic invite code.");
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    await cli.action.stop();
+    console.log("");
 
     if (res.method === 0) {
       const emailsRes = await inquirer.prompt([
@@ -66,12 +66,12 @@ export default class CommandBase {
         },
       ]);
       console.log("Email res is", emailsRes.emails);
-      await cli.action.start("Sending invites");
+      await console.log("Sending invites");
       const inviteRes = await inviteProjectMembers(
         projectConfig.project,
         emailsRes.emails.split(",")
       );
-      await cli.action.stop();
+      console.log("");
       console.log(
         "\nInvited your folks to use crusher!. Ask them to check there mail."
       );

--- a/packages/cli/src/commands/test/create.ts
+++ b/packages/cli/src/commands/test/create.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { loadUserInfoOnLoad } from "../../utils/hooks";
 import { getUserInfo } from "../../state/userInfo";
 import { getRecorderDistCommand, resolvePathToAppDirectory } from "../../utils/utils";
-import cli from "cli-ux";
+
 import { getProjectConfig, getProjectConfigPath } from "../../utils/projectConfig";
 import { execSync } from "child_process";
 import localTunnel from "localtunnel";
@@ -70,7 +70,7 @@ export default class CommandBase {
       tunnel = await createTunnel(port);
       const host = tunnel.url;
 
-      await cli.log("\nServing at " + host + " now \n");
+      await console.log("\nServing at " + host + " now \n");
     }
 
     const projectConfig = getProjectConfig();
@@ -83,11 +83,11 @@ export default class CommandBase {
   
     execSync(`${getRecorderDistCommand()} ${customFlags} --no-sandbox --open-recorder --projectId=${projectId} --token=${userToken}`, {stdio: "ignore"});
 
-    cli.log("Created your test. Few command that might be helpful\n");
-    cli.log("1.) Run all tests in your project");
-    cli.log(`${chalk.hex("9A4AFF")(`npx crusher-cli test:run`)}`);
+    console.log("Created your test. Few command that might be helpful\n");
+    console.log("1.) Run all tests in your project");
+    console.log(`${chalk.hex("9A4AFF")(`npx crusher-cli test:run`)}`);
 
-    cli.log("2.) Invite team members to the project");
-    cli.log(`${chalk.hex("9A4AFF")(`npx crusher-cli invite`)}`);
+    console.log("2.) Invite team members to the project");
+    console.log(`${chalk.hex("9A4AFF")(`npx crusher-cli invite`)}`);
   }
 }

--- a/packages/cli/src/commands/tunnel.ts
+++ b/packages/cli/src/commands/tunnel.ts
@@ -1,10 +1,7 @@
 import { Command } from "commander";
 
-import { cli } from "cli-ux";
-import { runTests } from "../utils/apiUtils";
 import { getProjectConfig } from "../utils/projectConfig";
 import { loadUserInfoOnLoad } from "../utils/hooks";
-import { getUserInfo } from "../state/userInfo";
 import { Cloudflare } from "../module/cloudflare";
 import fs from "fs";
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -11,9 +11,10 @@ export const APP_DIRECTORY =
 
 export const recorderVersion = process.env.RECORDER_VERSION || `1.0.33`;
 
-export const RECORDER_MAC_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-x64.zip`);
-export const RECORDER_MAC_ARM64_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-arm64.zip`);
-export const RECORDER_LINUX_BUILd = url.resolve(process.env.DOWNLOADS_REPO_URL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-linux.zip`);
+const repoDownloadURL = "https://github.com/crusher-dev/crusher-debug-downloads/"
+export const RECORDER_MAC_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL || repoDownloadURL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-x64.zip`);
+export const RECORDER_MAC_ARM64_BUILD = url.resolve(process.env.DOWNLOADS_REPO_URL || repoDownloadURL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-mac-arm64.zip`);
+export const RECORDER_LINUX_BUILd = url.resolve(process.env.DOWNLOADS_REPO_URL || repoDownloadURL, `./releases/download/v${recorderVersion}/Crusher.Recorder-${recorderVersion}-linux.zip`);
 
 export const CLOUDFLARED_URL = {
   MAC: "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz",

--- a/packages/cli/src/module/cloudflare.ts
+++ b/packages/cli/src/module/cloudflare.ts
@@ -1,5 +1,5 @@
 import { downloadFile } from "../utils/common";
-import cli from "cli-ux";
+
 import { resolveBackendServerUrl, resolvePathToAppDirectory } from "../utils/utils";
 import { execSync } from "child_process";
 import path from "path";
@@ -11,10 +11,12 @@ import { CLOUDFLARED_URL } from "../constants";
 
 var { spawn, exec } = require("child_process");
 const fs = require("fs");
+const cliProgress = require('cli-progress');
 
 async function installNSetupOnMac() {
   const recorderZipPath = resolvePathToAppDirectory(`cloudflare.tgz`);
-  const bar = cli.progress({
+  
+  const bar = new cliProgress.SingleBar({
     format: `Downloading cloudflare tunnel {percentage}%`,
   });
 
@@ -34,7 +36,7 @@ async function installNSetupOnMac() {
 
 async function installLinuxBuild() {
   const recorderZipPath = resolvePathToAppDirectory(`bin/cloudflared`);
-  const bar = cli.progress({
+  const bar = new cliProgress.SingleBar({
     format: `Downloading cloudflare tunnel {percentage}%`,
   });
 

--- a/packages/cli/src/utils/apiUtils.ts
+++ b/packages/cli/src/utils/apiUtils.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { cli } from "cli-ux";
 import { getUserInfo } from "../state/userInfo";
 import { getLoggedInUser } from "../utils/index";
 import {
@@ -156,7 +155,7 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
     const projectConfig = getProjectConfig();
     _projectId = projectConfig.project;
   }
-  await cli.action.start("Running tests now");
+  await console.log("Running tests now");
 
   try {
     const context = getContextEnvVariables();
@@ -182,12 +181,12 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
       }
     );
 
-    await cli.action.stop();
+    console.log("");
 
     const buildInfo = res.data.buildInfo;
     const buildId = buildInfo.buildId;
 
-    await cli.action.start("Waiting for tests to finish");
+    await console.log("Waiting for tests to finish");
     // sleep for 20 seconds
     await new Promise((resolve) => {
       // create a poll to check if tests are done
@@ -210,12 +209,12 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
           buildInfo.status === "MANUAL_REVIEW_REQUIRED"
         ) {
           clearInterval(poll);
-          await cli.action.stop(
+          console.log(
             buildInfo.status === "PASSED"
               ? `Build passed in ${parseInt(buildInfo.duration)}s`
               : `Build failed in ${parseInt(buildInfo.duration)}s`
           );
-          await cli.log(
+          await console.log(
             "View build report at " +
               resolveFrontendServerUrl(`/app/build/${buildId}`)
           );
@@ -225,7 +224,7 @@ const runTests = async (host: string | undefined, proxyUrlsMap: { [name: string]
     });
   } catch (err: any) {
     console.error(err);
-    await cli.action.stop(err.message);
+    console.error(err.message);
   }
 };
 

--- a/packages/cli/src/utils/common.ts
+++ b/packages/cli/src/utils/common.ts
@@ -1,7 +1,5 @@
 import axios from "axios";
-import { resolve } from "dns";
 import * as fs from "fs";
-import cli from "cli-ux";
 import * as pathModule from "path";
 
 export const downloadFile = (url, path, bar): Promise<string> => {

--- a/packages/cli/src/utils/hooks.ts
+++ b/packages/cli/src/utils/hooks.ts
@@ -9,6 +9,10 @@ import axios from "axios";
 import chalk from "chalk";
 import { isUserLoggedIn } from ".";
 const open = require('open');
+
+import ora from 'ora';
+
+
 /*
     Crusher secret invite code. Don't share it with anyone🤫
 */
@@ -18,10 +22,11 @@ const secretInviteCode = "crush"
   Remove this after beta
 */
 const checkForDiscord = async()=>{
+
   const isCodeInCommandLine = process.argv.some((e)=>{
     return e.includes("--code=") && !["help", "--help", "-h"].includes(e)
   })
-  const hasLoginFlag = process.argv.some((e) => e.includes("--login"));
+  const hasLoginFlag = process.argv.some((e) => e.includes("login"));
 
 
   if(isUserLoggedIn() || isCodeInCommandLine) return;
@@ -30,11 +35,11 @@ const checkForDiscord = async()=>{
     await console.log(chalk.green(`New to crusher?`))
 
     await console.log(`Get access code - ${chalk.green("https://discord.gg/dHZkSNXQrg")}`)
-  await console.log(`1.) Get access code on home screen`)
-  await console.log(`2.) Run command with access code`)
+    await console.log(`1.) Get access code on home screen`)
+    await console.log(`2.) Run command with access code`)
 
     await console.log(`\n${chalk.yellow('Already have an account?')}
-    run npx crusher-cli --login \n`)
+    run npx crusher-cli login \n`)
 
   process.exit(0)
   }
@@ -66,7 +71,8 @@ const waitForUserLogin = async (): Promise<string> => {
     "Login or create an account to create/sync tests⚡⚡. Opening a browser to sync test.\nOr open this link:"
   );
   await console.log(`${loginUrl} \n`);
-  await console.log("Waiting for login");
+
+  const spinner = ora('Waiting for login').start();
 
   await open(loginUrl)
     .catch((err) => {
@@ -85,7 +91,7 @@ const waitForUserLogin = async (): Promise<string> => {
     }, 5000);
   });
 
-  console.log("");
+  spinner.stop()
 
   await console.log("\nLogin completed! Let's ship high quality software fast⚡⚡");
   return token as string;

--- a/packages/cli/src/utils/hooks.ts
+++ b/packages/cli/src/utils/hooks.ts
@@ -6,10 +6,9 @@ import {
   resolveFrontendServerUrl,
 } from "../utils/utils";
 import axios from "axios";
-import cli from "cli-ux";
 import chalk from "chalk";
 import { isUserLoggedIn } from ".";
-
+const open = require('open');
 /*
     Crusher secret invite code. Don't share it with anyone🤫
 */
@@ -28,13 +27,13 @@ const checkForDiscord = async()=>{
   if(isUserLoggedIn() || isCodeInCommandLine) return;
 
   if(!isCodeInCommandLine && !hasLoginFlag){
-    await cli.log(chalk.green(`New to crusher?`))
+    await console.log(chalk.green(`New to crusher?`))
 
-    await cli.log(`Get access code - ${chalk.green("https://discord.gg/dHZkSNXQrg")}`)
-  await cli.log(`1.) Get access code on home screen`)
-  await cli.log(`2.) Run command with access code`)
+    await console.log(`Get access code - ${chalk.green("https://discord.gg/dHZkSNXQrg")}`)
+  await console.log(`1.) Get access code on home screen`)
+  await console.log(`2.) Run command with access code`)
 
-    await cli.log(`\n${chalk.yellow('Already have an account?')}
+    await console.log(`\n${chalk.yellow('Already have an account?')}
     run npx crusher-cli --login \n`)
 
   process.exit(0)
@@ -63,14 +62,13 @@ const waitForUserLogin = async (): Promise<string> => {
     });
   const loginUrl = resolveFrontendServerUrl(`/login_sucessful?lK=${loginKey}&inviteCode=${discordCode}`);
 
-  await cli.log(
+  await console.log(
     "Login or create an account to create/sync tests⚡⚡. Opening a browser to sync test.\nOr open this link:"
   );
-  await cli.log(`${loginUrl} \n`);
-  await cli.action.start("Waiting for login");
+  await console.log(`${loginUrl} \n`);
+  await console.log("Waiting for login");
 
-  await cli
-    .open(loginUrl)
+  await open(loginUrl)
     .catch((err) => {
       console.error(err);
     });
@@ -87,9 +85,9 @@ const waitForUserLogin = async (): Promise<string> => {
     }, 5000);
   });
 
-  await cli.action.stop();
+  console.log("");
 
-  await cli.log("\nLogin completed! Let's ship high quality software fast⚡⚡");
+  await console.log("\nLogin completed! Let's ship high quality software fast⚡⚡");
   return token as string;
 };
 

--- a/packages/cli/src/utils/projectConfig.ts
+++ b/packages/cli/src/utils/projectConfig.ts
@@ -64,7 +64,7 @@ export const getProjectConfig = (verbose: boolean = true) => {
 
   if(!hasLoggedProjectConfig) {
     hasLoggedProjectConfig = true;
-    console.log(chalk.green("Using project config: ") + configPath);
+    console.log(chalk.green("Using config: ") + configPath);
   }
   hasLoggedProjectConfig = true;
   if(configPath.endsWith(".js")) { const requireOriginal = eval("require"); const config = requireOriginal(configPath); return config; }

--- a/packages/cli/src/utils/setup.ts
+++ b/packages/cli/src/utils/setup.ts
@@ -15,6 +15,7 @@ import { getProjectNameFromGitInfo } from "./index";
 import { getAppConfig, setAppConfig } from "../utils/appConfig";
 import { downloadFile } from "./common";
 import chalk from "chalk";
+import ora from "ora";
 const cliProgress = require('cli-progress');
 
 export async function makeSureSetupIsCorrect(projectId: string | null = null, ask = false) {
@@ -118,9 +119,6 @@ async function downloadUpstreamBuild(): Promise<string> {
   const bar = new cliProgress.SingleBar({
     format: `Downloading latest version (${packagesRecorderUrl.version})\t[{bar}] {percentage}%`,
   }, cliProgress.Presets.shades_classic);
-  // const bar = cli.progress({
-  //   format: `Downloading latest version (${packagesRecorderUrl.version})\t[{bar}] {percentage}%`,
-  // });
   bar.start(100, 0, { speed: "N/A" });
 
   return downloadFile(packagesRecorderUrl.url, recorderZipPath, bar);
@@ -137,7 +135,8 @@ async function installMacBuild() {
   }
   const recorderZipPath = await downloadUpstreamBuild();
 
-  await console.log("Unzipping");
+
+  const spinner = ora('Unzipping').start();
   if (fs.existsSync(resolvePathToAppDirectory("bin/Crusher Recorder.app"))) {
     execSync(
       `cd ${path.dirname(recorderZipPath)} && rm -Rrf "Crusher Recorder.app"`
@@ -155,6 +154,7 @@ async function installMacBuild() {
       resolve(true);
     }, 3000)
   );
+  spinner.stop()
   console.log("done\n");
 }
 
@@ -170,7 +170,7 @@ async function installLinuxBuild() {
   }
   const recorderZipPath = await downloadUpstreamBuild();
 
-  await console.log("Unzipping");
+  const spinner = ora('Unzipping').start();
   execSync(
     `cd ${path.dirname(recorderZipPath)} && unzip ${path.basename(
       recorderZipPath
@@ -183,6 +183,7 @@ async function installLinuxBuild() {
       resolve(true);
     }, 3000)
   );
+  spinner.stop()
   console.log("done\n");
 }
 
@@ -222,10 +223,10 @@ export async function installCrusherRecorder() {
 }
 
 export async function createTunnel(port: string): Promise<localTunnel.Tunnel> {
-  await console.log("Creating tunnel to local system");
+  const spinner = ora('Creating tunnel to local system').start();
   // eslint-disable-next-line radix
   const tunnel = await localTunnel({ port: parseInt(port) });
-  console.log("");
+  spinner.stop()
 
   tunnel.on("close", () => {
     console.log(`Tunnel for http://localhost:${port} closed`);

--- a/packages/cli/src/utils/setup.ts
+++ b/packages/cli/src/utils/setup.ts
@@ -3,11 +3,10 @@ import {
   resolvePathToAppDirectory,
 } from "../utils/utils";
 import * as fs from "fs";
-import axios from "axios";
 import * as path from "path";
 import { getRecorderBuildForPlatfrom, recorderVersion } from "../constants";
-import cli from "cli-ux";
-import { getProjectConfig, getProjectConfigPath, getSuggestedProjectConfigPath, setProjectConfig } from "../utils/projectConfig";
+
+import { getProjectConfig, getSuggestedProjectConfigPath, setProjectConfig } from "../utils/projectConfig";
 import { execSync } from "child_process";
 import * as inquirer from "inquirer";
 import { getProjectsOfCurrentUser, createProject } from "../utils/apiUtils";
@@ -16,6 +15,7 @@ import { getProjectNameFromGitInfo } from "./index";
 import { getAppConfig, setAppConfig } from "../utils/appConfig";
 import { downloadFile } from "./common";
 import chalk from "chalk";
+const cliProgress = require('cli-progress');
 
 export async function makeSureSetupIsCorrect(projectId: string | null = null, ask = false) {
   const projectConfig = getProjectConfig();
@@ -115,9 +115,12 @@ async function downloadUpstreamBuild(): Promise<string> {
     `bin/${packagesRecorderUrl.name}`
   );
 
-  const bar = cli.progress({
+  const bar = new cliProgress.SingleBar({
     format: `Downloading latest version (${packagesRecorderUrl.version})\t[{bar}] {percentage}%`,
-  });
+  }, cliProgress.Presets.shades_classic);
+  // const bar = cli.progress({
+  //   format: `Downloading latest version (${packagesRecorderUrl.version})\t[{bar}] {percentage}%`,
+  // });
   bar.start(100, 0, { speed: "N/A" });
 
   return downloadFile(packagesRecorderUrl.url, recorderZipPath, bar);
@@ -127,14 +130,14 @@ async function installMacBuild() {
   // handle when crusher is already installed
   if(fs.existsSync(resolvePathToAppDirectory("bin"))) {
     execSync(`rm -Rf ${resolvePathToAppDirectory("bin")} && mkdir ${resolvePathToAppDirectory("bin")}`);
-    cli.info("New version available! Updating now...\n");
+    console.log("New version available! Updating now...\n");
   } else {
     execSync(`mkdir ${resolvePathToAppDirectory("bin")}`);
-    cli.info("Crusher Recorder is not installed.\n");
+    console.log("Crusher Recorder is not installed.\n");
   }
   const recorderZipPath = await downloadUpstreamBuild();
 
-  await cli.action.start("Unzipping");
+  await console.log("Unzipping");
   if (fs.existsSync(resolvePathToAppDirectory("bin/Crusher Recorder.app"))) {
     execSync(
       `cd ${path.dirname(recorderZipPath)} && rm -Rrf "Crusher Recorder.app"`
@@ -152,7 +155,7 @@ async function installMacBuild() {
       resolve(true);
     }, 3000)
   );
-  await cli.action.stop("done\n");
+  console.log("done\n");
 }
 
 async function installLinuxBuild() {
@@ -160,14 +163,14 @@ async function installLinuxBuild() {
 
   if(fs.existsSync(resolvePathToAppDirectory("bin"))) {
     execSync(`rm -Rf ${resolvePathToAppDirectory("bin")} && mkdir ${resolvePathToAppDirectory("bin")}`);
-    cli.info("New version available! Updating now...\n");
+    console.log("New version available! Updating now...\n");
   } else {
     execSync(`mkdir ${resolvePathToAppDirectory("bin")}`);
-    cli.info("Crusher Recorder is not installed.\n");
+    console.log("Crusher Recorder is not installed.\n");
   }
   const recorderZipPath = await downloadUpstreamBuild();
 
-  await cli.action.start("Unzipping");
+  await console.log("Unzipping");
   execSync(
     `cd ${path.dirname(recorderZipPath)} && unzip ${path.basename(
       recorderZipPath
@@ -180,7 +183,7 @@ async function installLinuxBuild() {
       resolve(true);
     }, 3000)
   );
-  await cli.action.stop("done\n");
+  console.log("done\n");
 }
 
 export async function installCrusherRecorder() {
@@ -219,13 +222,13 @@ export async function installCrusherRecorder() {
 }
 
 export async function createTunnel(port: string): Promise<localTunnel.Tunnel> {
-  await cli.action.start("Creating tunnel to local system");
+  await console.log("Creating tunnel to local system");
   // eslint-disable-next-line radix
   const tunnel = await localTunnel({ port: parseInt(port) });
-  await cli.action.stop();
+  console.log("");
 
   tunnel.on("close", () => {
-    cli.log(`Tunnel for http://localhost:${port} closed`);
+    console.log(`Tunnel for http://localhost:${port} closed`);
     process.exit(0);
   });
   return tunnel;

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -27,11 +27,10 @@ module.exports = {
   mode: "production",
   entry: glob.sync("./src/bin/*.ts").reduce(function (obj, el) {
     obj[el.replace(".ts", "")] = {
-      import: el,
-      dependOn: "./src/shared",
+      import: el
     };
     return obj;
-  }, {"./src/shared": "cli-ux"}),
+  }, {}),
   node: {
     __dirname: false,
   },
@@ -57,8 +56,8 @@ module.exports = {
     new webpack.DefinePlugin({
       ...environmentVariables
     }),
-    new FixSharedOutputPlugin(),
-    // new BundleAnalyzerPlugin()
+    // new FixSharedOutputPlugin(),
+    new BundleAnalyzerPlugin({generateStatsFile: true})
   ],
   optimization: {
     splitChunks: {

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -3,6 +3,8 @@ const glob = require("glob");
 const webpack = require("webpack");
 const { FixSharedOutputPlugin } = require("./webpack/plugins/fixShardOutput");
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+var WebpackBundleSizeAnalyzerPlugin = require('webpack-bundle-size-analyzer').WebpackBundleSizeAnalyzerPlugin;
+const StatoscopeWebpackPlugin = require('@statoscope/webpack-plugin').default;
 
 console.log( glob.sync("./src/**/*.ts").reduce(function (obj, el) {
   obj[el.replace(".ts", "")] = {
@@ -56,8 +58,10 @@ module.exports = {
     new webpack.DefinePlugin({
       ...environmentVariables
     }),
+    // new StatoscopeWebpackPlugin()
     // new FixSharedOutputPlugin(),
-    new BundleAnalyzerPlugin({generateStatsFile: true})
+    // new BundleAnalyzerPlugin({generateStatsFile: true}),
+    // new WebpackBundleSizeAnalyzerPlugin('./reports/plain-report.txt')
   ],
   optimization: {
     splitChunks: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,7 @@ importers:
       '@commitlint/cli': ^13.1.0
       '@commitlint/config-conventional': ^13.1.0
       '@commitlint/prompt': ^13.1.0
+      '@statoscope/webpack-plugin': ^5.24.0
       '@types/fs-extra': ^9.0.13
       '@types/jest': ^27.0.1
       '@types/node': ^16.9.4
@@ -101,11 +102,14 @@ importers:
       uuid: ^8.3.2
       webpack: 5.73.0
       webpack-bundle-analyzer: ^4.6.1
+      webpack-bundle-size-analyzer: ^3.1.0
       webpack-cli: ^4.10.0
     dependencies:
+      '@statoscope/webpack-plugin': 5.24.0_webpack@5.73.0
       cli-progress: 3.11.2
       open: 8.4.0
       webpack-bundle-analyzer: 4.6.1
+      webpack-bundle-size-analyzer: 3.1.0
     devDependencies:
       '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.16.7
       '@babel/preset-env': 7.18.9_@babel+core@7.16.7
@@ -3853,6 +3857,16 @@ packages:
   /@discoveryjs/json-ext/0.5.3:
     resolution: {integrity: sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==}
     engines: {node: '>=10.0.0'}
+
+  /@discoveryjs/json-ext/0.5.7:
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
+    dev: false
+
+  /@discoveryjs/natural-compare/1.0.0:
+    resolution: {integrity: sha512-Pq35vJMxLZq4whZhyaMGO/89mmFee2+6NojaXD2bNo+7CxI6P7C1tncgQ0CM60+WueRMr8uFDKSX/8KitImCQg==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+    dev: false
 
   /@electron/get/1.12.4:
     resolution: {integrity: sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==}
@@ -7621,6 +7635,128 @@ packages:
     dependencies:
       '@sinonjs/commons': 1.8.3
 
+  /@statoscope/extensions/5.14.1:
+    resolution: {integrity: sha512-5O31566+bOkkdYFH81mGGBTh0YcU0zoYurTrsK5uZfpNY87ZCPpptrszX8npTRHNsxbjBBNt7vAwImJyYdhzLw==}
+    dev: false
+
+  /@statoscope/helpers/5.24.0:
+    resolution: {integrity: sha512-PhCynDA+FHB1DuuHlMeVnETRRDfgKrQTGey2jhBdHzd/Gae/GuwDcnFxiRVMIA97UQM8EwyE/hc0sF6dpPXd9w==}
+    dependencies:
+      '@types/archy': 0.0.32
+      '@types/semver': 7.3.12
+      archy: 1.0.0
+      jora: 1.0.0-beta.7
+      semver: 7.3.7
+    dev: false
+
+  /@statoscope/report-writer/5.22.0:
+    resolution: {integrity: sha512-oEIlfsMSwBM8PcHnHDwhgMz5fyDgu10oAVFwuQSJFBUXMwaZ/46ewr1kfAcUNc8CkOIolhO6EIo/e0ZjcVCR1g==}
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+    dev: false
+
+  /@statoscope/stats-extension-compressed/5.24.0:
+    resolution: {integrity: sha512-QRgTY7wnJhB5BjV2OHt2e3E8rLi+53LEJ2q7KZDjRMNZNGY6G1LPIuHTCAUlcLNxDbaeATqkioTVRyf2v9SjPQ==}
+    dependencies:
+      '@statoscope/helpers': 5.24.0
+      gzip-size: 6.0.0
+    dev: false
+
+  /@statoscope/stats-extension-custom-reports/5.24.0:
+    resolution: {integrity: sha512-n20dL3WYrwla8eCYNtHY0AdcBuyHiaW1F2gQBsJqV3PJzIYBijo/f1dHl2p8hzVDQmJ/QYWNwsbTvr1GQGdseg==}
+    dependencies:
+      '@statoscope/extensions': 5.14.1
+      '@statoscope/helpers': 5.24.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/types': 5.22.0
+    dev: false
+
+  /@statoscope/stats-extension-package-info/5.24.0:
+    resolution: {integrity: sha512-L7UtVb5CwG2dMZdVrGjok4+0ryEASO1rr8Kf/QzcQNIHb8mG5VSYRFBlcFfvvC/PNKafxoexbwhiSGZEtggwqw==}
+    dependencies:
+      '@statoscope/helpers': 5.24.0
+    dev: false
+
+  /@statoscope/stats-extension-stats-validation-result/5.24.0:
+    resolution: {integrity: sha512-++8hX2cb0CpIM+gqLwIl9N/ISJHTKtrQXwsl9CSlds3K4D49BwC2cULlvhGdjVRMf7U1RI0COL9dj79K7iK5Ig==}
+    dependencies:
+      '@statoscope/extensions': 5.14.1
+      '@statoscope/helpers': 5.24.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/types': 5.22.0
+    dev: false
+
+  /@statoscope/stats/5.14.1:
+    resolution: {integrity: sha512-Kz7kCKuT6DXaqAPfyTwp27xHMDUna9o6UlRSQXXBZ8Yyk7eYYvTNw+5ffRyqivL9IOzD7FQYDQ6VUBHh0UfyDw==}
+    dev: false
+
+  /@statoscope/types/5.22.0:
+    resolution: {integrity: sha512-FHgunU7M95v7c71pvQ2nr8bWy1QcTDOHSnkoFQErORH9RmxlK9oRkoWrO8BJpnxa55m/9ZHjFVmpLF4SsVGHoA==}
+    dependencies:
+      '@statoscope/stats': 5.14.1
+    dev: false
+
+  /@statoscope/webpack-model/5.24.0:
+    resolution: {integrity: sha512-6XHhTbA4Vw8LKUGLuRvsNUUgiiGAvqciUMQRjovf2xNRT2a3rCP7L3QKOntEvIBcKzNGuQ0T+L5sKF8pqiI3mA==}
+    dependencies:
+      '@statoscope/extensions': 5.14.1
+      '@statoscope/helpers': 5.24.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-compressed': 5.24.0
+      '@statoscope/stats-extension-custom-reports': 5.24.0
+      '@statoscope/stats-extension-package-info': 5.24.0
+      '@statoscope/stats-extension-stats-validation-result': 5.24.0
+      '@statoscope/types': 5.22.0
+      md5: 2.3.0
+    dev: false
+
+  /@statoscope/webpack-plugin/5.24.0_webpack@5.73.0:
+    resolution: {integrity: sha512-8GX0ULmvwZRAqQClLMdzV1L/Y9PBJZTwBTXiiKzU4+vypRiI7VA+fz9aZ2XGWErVonXbrIvclj2IAQMbz/z2YQ==}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@statoscope/report-writer': 5.22.0
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-compressed': 5.24.0
+      '@statoscope/stats-extension-custom-reports': 5.24.0
+      '@statoscope/types': 5.22.0
+      '@statoscope/webpack-model': 5.24.0
+      '@statoscope/webpack-stats-extension-compressed': 5.24.0_webpack@5.73.0
+      '@statoscope/webpack-stats-extension-package-info': 5.24.0_webpack@5.73.0
+      '@statoscope/webpack-ui': 5.24.0
+      open: 8.4.0
+      webpack: 5.73.0_webpack-cli@4.10.0
+    dev: false
+
+  /@statoscope/webpack-stats-extension-compressed/5.24.0_webpack@5.73.0:
+    resolution: {integrity: sha512-yJyYo/TC393MZcA/txnd/37WubSdGNpVAncFlifVtJoGgsD9GrqltN8aUiaVPBDy/r4N4qP9+8T6OQ/Ha4J4DA==}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-compressed': 5.24.0
+      '@statoscope/webpack-model': 5.24.0
+      webpack: 5.73.0_webpack-cli@4.10.0
+    dev: false
+
+  /@statoscope/webpack-stats-extension-package-info/5.24.0_webpack@5.73.0:
+    resolution: {integrity: sha512-AXtYSbvyyFdgn1H/bnE2gu0oEhKBiHbeZA/gCJM+hEWOwGWnz61+qiPxYj2QnOnXN8XmjHho3jf0Gd4eW3dJfw==}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@statoscope/stats': 5.14.1
+      '@statoscope/stats-extension-package-info': 5.24.0
+      '@statoscope/webpack-model': 5.24.0
+      webpack: 5.73.0_webpack-cli@4.10.0
+    dev: false
+
+  /@statoscope/webpack-ui/5.24.0:
+    resolution: {integrity: sha512-tqNH1O7WE8dVa2WknmmM4j7mYD6mna3TKRLRYmiAwg6W/RICVAxXwZy1v9uKN9+pfa6By0hI3mWiYS7V1seh2w==}
+    dependencies:
+      '@statoscope/types': 5.22.0
+    dev: false
+
   /@stitches/react/1.2.8_react@17.0.2:
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
     peerDependencies:
@@ -9528,6 +9664,10 @@ packages:
       '@types/glob': 7.1.3
     dev: false
 
+  /@types/archy/0.0.32:
+    resolution: {integrity: sha512-5ZZ5+YGmUE01yejiXsKnTcvhakMZ2UllZlMsQni53Doc1JWhe21ia8VntRoRD6fAEWw08JBh/z9qQHJ+//MrIg==}
+    dev: false
+
   /@types/aria-query/4.2.2:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
     dev: false
@@ -9659,7 +9799,6 @@ packages:
     dependencies:
       '@types/eslint': 7.2.14
       '@types/estree': 0.0.51
-    dev: true
 
   /@types/eslint/7.2.14:
     resolution: {integrity: sha512-pESyhSbUOskqrGcaN+bCXIQDyT5zTaRWfj5ZjjSlMatgGjIn3QQPfocAu4WSabUR7CGyLZ2CQaZyISOEX7/saw==}
@@ -10092,6 +10231,10 @@ packages:
   /@types/scheduler/0.16.1:
     resolution: {integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==}
 
+  /@types/semver/7.3.12:
+    resolution: {integrity: sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==}
+    dev: false
+
   /@types/semver/7.3.9:
     resolution: {integrity: sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==}
     dev: false
@@ -10375,7 +10518,6 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-    dev: true
 
   /@webassemblyjs/ast/1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -10389,7 +10531,6 @@ packages:
 
   /@webassemblyjs/floating-point-hex-parser/1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
-    dev: true
 
   /@webassemblyjs/floating-point-hex-parser/1.9.0:
     resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
@@ -10399,7 +10540,6 @@ packages:
 
   /@webassemblyjs/helper-api-error/1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
-    dev: true
 
   /@webassemblyjs/helper-api-error/1.9.0:
     resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
@@ -10409,7 +10549,6 @@ packages:
 
   /@webassemblyjs/helper-buffer/1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
-    dev: true
 
   /@webassemblyjs/helper-buffer/1.9.0:
     resolution: {integrity: sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==}
@@ -10440,14 +10579,12 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.1
       '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.0:
     resolution: {integrity: sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==}
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
-    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.9.0:
     resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
@@ -10467,7 +10604,6 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
-    dev: true
 
   /@webassemblyjs/helper-wasm-section/1.9.0:
     resolution: {integrity: sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==}
@@ -10486,7 +10622,6 @@ packages:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
-    dev: true
 
   /@webassemblyjs/ieee754/1.9.0:
     resolution: {integrity: sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==}
@@ -10502,7 +10637,6 @@ packages:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/leb128/1.9.0:
     resolution: {integrity: sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==}
@@ -10514,7 +10648,6 @@ packages:
 
   /@webassemblyjs/utf8/1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
-    dev: true
 
   /@webassemblyjs/utf8/1.9.0:
     resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
@@ -10542,7 +10675,6 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
       '@webassemblyjs/wast-printer': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-edit/1.9.0:
     resolution: {integrity: sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==}
@@ -10573,7 +10705,6 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-gen/1.9.0:
     resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
@@ -10599,7 +10730,6 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-opt/1.9.0:
     resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
@@ -10628,7 +10758,6 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-parser/1.9.0:
     resolution: {integrity: sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==}
@@ -10661,7 +10790,6 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/wast-printer/1.9.0:
     resolution: {integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==}
@@ -10688,7 +10816,6 @@ packages:
     dependencies:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
-    dev: true
 
   /@webpack-cli/configtest/1.2.0_aa73yiufjzrs5dnjm4asji72by:
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
@@ -10723,7 +10850,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_ptzbz4bao7we2onwdcwwuffqhy
+      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   /@webpack-cli/serve/1.5.1_r5jz6ab5h5z5ui7vgheqnt6cae:
     resolution: {integrity: sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==}
@@ -10747,7 +10874,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_webpack@5.39.1
+      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   /@webpack-cli/serve/1.7.0_xcsigq56yu4htn6anmcckynncu:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -10866,7 +10993,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.7.1
-    dev: true
 
   /acorn-jsx/5.3.1_acorn@7.4.1:
     resolution: {integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==}
@@ -11347,7 +11473,6 @@ packages:
 
   /archy/1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
-    dev: true
 
   /are-we-there-yet/2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
@@ -11780,7 +11905,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.14.7_debug@4.3.3
+      follow-redirects: 1.14.7
     transitivePeerDependencies:
       - debug
 
@@ -15967,7 +16092,6 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       tapable: 2.2.0
-    dev: true
 
   /enhanced-resolve/5.8.2:
     resolution: {integrity: sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==}
@@ -16057,7 +16181,6 @@ packages:
 
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
-    dev: true
 
   /es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
@@ -17236,6 +17359,11 @@ packages:
     dependencies:
       minimatch: 3.1.2
 
+  /filesize/3.6.1:
+    resolution: {integrity: sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==}
+    engines: {node: '>= 0.4.0'}
+    dev: false
+
   /filesize/6.1.0:
     resolution: {integrity: sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==}
     engines: {node: '>= 0.4.0'}
@@ -17476,6 +17604,15 @@ packages:
   /focus-outline-manager/1.0.2:
     resolution: {integrity: sha512-bHWEmjLsTjGP9gVs7P3Hyl+oY5NlMW8aTSPdTJ+X2GKt6glDctt9fUCLbRV+d/l8NDC40+FxMjp9WlTQXaQALw==}
     dev: false
+
+  /follow-redirects/1.14.7:
+    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   /follow-redirects/1.14.7_debug@4.3.3:
     resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
@@ -18895,6 +19032,10 @@ packages:
   /human-signals/2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  /humanize/0.0.9:
+    resolution: {integrity: sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q==}
+    dev: false
 
   /husky/6.0.0:
     resolution: {integrity: sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==}
@@ -20994,6 +21135,13 @@ packages:
 
   /join-component/1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
+    dev: false
+
+  /jora/1.0.0-beta.7:
+    resolution: {integrity: sha512-7Mq37XUPQM/fEetH8Z4iHTABWgoq64UL9mIRfssX1b0Ogns3TqbOS0UIV7gwQ3D0RshfLJzGgbbW17UyFjxSLQ==}
+    engines: {node: ^10.12.0 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      '@discoveryjs/natural-compare': 1.0.0
     dev: false
 
   /jotai/1.4.7_taaswbfv5gpjqrwqwdhq6newyu:
@@ -30524,7 +30672,6 @@ packages:
       source-map: 0.6.1
       terser: 5.13.1
       webpack: 5.73.0_webpack-cli@4.10.0
-    dev: true
 
   /terser-webpack-plugin/5.3.1_zjtckeea76d3oit4tw4tcptpni:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -32064,7 +32211,6 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.9
-    dev: true
 
   /wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
@@ -32132,6 +32278,15 @@ packages:
       - bufferutil
       - utf-8-validate
 
+  /webpack-bundle-size-analyzer/3.1.0:
+    resolution: {integrity: sha512-8WlTT6uuCxZgZYNnCB0pRGukWRGH+Owg+HsqQUe1Zexakdno1eDYO+lE7ihBo9G0aCCZCJa8JWjYr9eLYfZrBA==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      filesize: 3.6.1
+      humanize: 0.0.9
+    dev: false
+
   /webpack-cli/3.3.12_webpack@5.39.1:
     resolution: {integrity: sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==}
     engines: {node: '>=6.11.5'}
@@ -32186,7 +32341,6 @@ packages:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.6.1
       webpack-merge: 5.8.0
-    dev: true
 
   /webpack-cli/4.10.0_ptzbz4bao7we2onwdcwwuffqhy:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
@@ -32631,7 +32785,6 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: true
 
   /webpack-virtual-modules/0.2.2:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
@@ -32998,7 +33151,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,7 +84,7 @@ importers:
       glob: ^7.2.0
       husky: ^7.0.2
       ini: ^3.0.0
-      inquirer: ^6.2.0
+      inquirer: ^9.1.0
       jest: ^27.2.0
       jsonfile: ^6.1.0
       lint-staged: ^11.1.2
@@ -131,7 +131,7 @@ importers:
       glob: 7.2.0
       husky: 7.0.4
       ini: 3.0.0
-      inquirer: 6.5.2
+      inquirer: 9.1.1
       jest: 27.4.7
       jsonfile: 6.1.0
       lint-staged: 11.2.6
@@ -316,7 +316,7 @@ importers:
       eslint-plugin-react-hooks: 4.2.0_eslint@7.30.0
       jest: 27.4.7
       next-images: 1.8.1_webpack@4.46.0
-      next-purgecss: 4.0.0
+      next-purgecss: 4.0.0_webpack@4.46.0
       next-transpile-modules: 6.4.1
       prettier: 2.3.2
       prettier-plugin-tailwind: 2.2.12_oxaym2ms6qfncwedb32pv23thq
@@ -575,7 +575,7 @@ importers:
       '@radix-ui/react-context-menu': 1.0.0_fdan6bnjkwodef3etrqalnirem
       '@radix-ui/react-icons': 1.1.1_react@17.0.2
       '@stitches/react': 1.2.8_react@17.0.2
-      '@storybook/addon-info': 5.3.21_kpnaldxznq4w6o534bf4fb74au
+      '@storybook/addon-info': 5.3.21_iyxxhekejclwcqxm4p27oyqaq4
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react': 11.2.7_sfoxds7t5ydpegc3knd667wn6m
       '@testing-library/user-event': 12.8.3_7izb363m7fjrh7ob6q4a2yqaqe
@@ -589,7 +589,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-joyride: 2.3.2_tpowlqvwbtughbcexafts2sidm
-      react-scripts: 4.0.3_x42bqxgwliwa4f7rcvhhje7sti
+      react-scripts: 4.0.3_e5z7iwxxkielgwr442hoaozk7u
       storybook-addon-designs: 6.3.1_react@17.0.2
       tailwindcss: /@tailwindcss/postcss7-compat/2.2.17
       typescript: 4.3.5
@@ -779,7 +779,7 @@ importers:
       electron-debug: 3.2.0
       electron-devtools-installer: 3.2.0
       electron-notarize: 1.1.1
-      electron-redux: 1.5.4
+      electron-redux: 1.5.4_redux@4.1.2
       electron-updater: 4.6.1
       electron-window-state: 5.0.3
       event-kit: 2.5.3
@@ -4121,7 +4121,6 @@ packages:
       '@emotion/serialize': 0.11.16
       '@emotion/utils': 0.11.3
       react: 17.0.2
-    dev: true
 
   /@emotion/styled-base/10.0.31_l4qwngn4rqpsicelhp3xw7f334:
     resolution: {integrity: sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==}
@@ -4146,7 +4145,6 @@ packages:
       '@emotion/styled-base': 10.0.31_go5tdyoyk4iceqw7gzblglw2da
       babel-plugin-emotion: 10.2.2
       react: 17.0.2
-    dev: true
 
   /@emotion/styled/10.0.27_l4qwngn4rqpsicelhp3xw7f334:
     resolution: {integrity: sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==}
@@ -4451,7 +4449,7 @@ packages:
   /@humanwhocodes/object-schema/1.2.0:
     resolution: {integrity: sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==}
 
-  /@hypnosphi/create-react-context/0.3.1_uutjjb2r36qagpytglxm7vtgnq:
+  /@hypnosphi/create-react-context/0.3.1_mv67koxdvxhyejehvpcoenu3ai:
     resolution: {integrity: sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==}
     peerDependencies:
       prop-types: ^15.0.0
@@ -4459,7 +4457,7 @@ packages:
     dependencies:
       gud: 1.0.0
       prop-types: 15.7.2
-      react: 16.14.0
+      react: 17.0.2
       warning: 4.0.3
 
   /@istanbuljs/load-nyc-config/1.1.0:
@@ -4598,7 +4596,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/node': 17.0.38
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
       graceful-fs: 4.2.9
@@ -7868,21 +7866,23 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-info/5.3.21_kpnaldxznq4w6o534bf4fb74au:
+  /@storybook/addon-info/5.3.21_iyxxhekejclwcqxm4p27oyqaq4:
     resolution: {integrity: sha512-A/K9HzmoXMuOUxH3AozTvjNZwTlYVHob2OaDRfMza0gYMzG0tOrxqcdNTigeAWAjS//Z0G3enue6rHulQZK/+g==}
+    peerDependencies:
+      react: '*'
     dependencies:
       '@storybook/addons': 5.3.21_tywxhxqgoy4ic6dja7arbokhba
       '@storybook/client-logger': 5.3.21
-      '@storybook/components': 5.3.21_@types+react@17.0.14
-      '@storybook/theming': 5.3.21_zkbncb2mrwigeq3keybbaytzya
+      '@storybook/components': 5.3.21_fdan6bnjkwodef3etrqalnirem
+      '@storybook/theming': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.15.2
       global: 4.4.0
       marksy: 8.0.0
       nested-object-assign: 1.0.4
       prop-types: 15.7.2
-      react: 16.14.0
+      react: 17.0.2
       react-addons-create-fragment: 15.6.2
-      react-element-to-jsx-string: 14.3.2_zkbncb2mrwigeq3keybbaytzya
+      react-element-to-jsx-string: 14.3.2_sfoxds7t5ydpegc3knd667wn6m
       react-is: 16.13.1
       react-lifecycles-compat: 3.0.4
       util-deprecate: 1.0.2
@@ -7950,7 +7950,7 @@ packages:
       '@storybook/addons': 5.3.21_tywxhxqgoy4ic6dja7arbokhba
       '@storybook/api': 5.3.21_tywxhxqgoy4ic6dja7arbokhba
       '@storybook/client-logger': 5.3.21
-      '@storybook/components': 5.3.21_@types+react@17.0.14
+      '@storybook/components': 5.3.21_fdan6bnjkwodef3etrqalnirem
       '@storybook/core-events': 5.3.21
       '@storybook/router': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/theming': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
@@ -8273,29 +8273,32 @@ packages:
       core-js: 3.15.2
       global: 4.4.0
 
-  /@storybook/components/5.3.21_@types+react@17.0.14:
+  /@storybook/components/5.3.21_fdan6bnjkwodef3etrqalnirem:
     resolution: {integrity: sha512-42QQk6qZl6wrtajP8yNCfmNS2t8Iod5QY+4V/l6iNnnT9O+j6cWOlnO+ZyvjNv0Xm0zIOt+VyVjdkKh8FUjQmA==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@storybook/client-logger': 5.3.21
-      '@storybook/theming': 5.3.21_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/theming': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
       '@types/react-syntax-highlighter': 11.0.4
       '@types/react-textarea-autosize': 4.3.6
       core-js: 3.15.2
       global: 4.4.0
       lodash: 4.17.21
-      markdown-to-jsx: 6.11.4_react@16.14.0
+      markdown-to-jsx: 6.11.4_react@17.0.2
       memoizerific: 1.11.3
       polished: 3.7.2
       popper.js: 1.16.1
       prop-types: 15.7.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
-      react-focus-lock: 2.5.2_nhp7wl2pwxhlzqos3czbs7ca5e
-      react-helmet-async: 1.0.9_wcqkhtmu7mswc6yz4uyexck3ty
-      react-popper-tooltip: 2.11.1_wcqkhtmu7mswc6yz4uyexck3ty
-      react-syntax-highlighter: 11.0.2_react@16.14.0
-      react-textarea-autosize: 7.1.2_react@16.14.0
-      simplebar-react: 1.2.3_wcqkhtmu7mswc6yz4uyexck3ty
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-focus-lock: 2.5.2_wl4y6gseskpemamwhbv27q43ni
+      react-helmet-async: 1.0.9_sfoxds7t5ydpegc3knd667wn6m
+      react-popper-tooltip: 2.11.1_sfoxds7t5ydpegc3knd667wn6m
+      react-syntax-highlighter: 11.0.2_react@17.0.2
+      react-textarea-autosize: 7.1.2_react@17.0.2
+      simplebar-react: 1.2.3_sfoxds7t5ydpegc3knd667wn6m
       ts-dedent: 1.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -8747,7 +8750,7 @@ packages:
       babel-plugin-react-docgen: 4.2.1
       pnp-webpack-plugin: 1.6.4_typescript@4.3.5
       react-docgen-typescript-plugin: 1.0.0_fh66qcvt6fztzjltdvxy4343yy
-      react-scripts: 4.0.3_x42bqxgwliwa4f7rcvhhje7sti
+      react-scripts: 4.0.3_e5z7iwxxkielgwr442hoaozk7u
       semver: 7.3.5
     transitivePeerDependencies:
       - react-refresh
@@ -9045,28 +9048,6 @@ packages:
       prop-types: 15.7.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      resolve-from: 5.0.0
-      ts-dedent: 1.2.0
-    dev: true
-
-  /@storybook/theming/5.3.21_wcqkhtmu7mswc6yz4uyexck3ty:
-    resolution: {integrity: sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-    dependencies:
-      '@emotion/core': 10.1.1_react@16.14.0
-      '@emotion/styled': 10.0.27_l4qwngn4rqpsicelhp3xw7f334
-      '@storybook/client-logger': 5.3.21
-      core-js: 3.15.2
-      deep-object-diff: 1.1.0
-      emotion-theming: 10.0.27_l4qwngn4rqpsicelhp3xw7f334
-      global: 4.4.0
-      memoizerific: 1.11.3
-      polished: 3.7.2
-      prop-types: 15.7.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
       resolve-from: 5.0.0
       ts-dedent: 1.2.0
 
@@ -9678,6 +9659,7 @@ packages:
     dependencies:
       '@types/eslint': 7.2.14
       '@types/estree': 0.0.51
+    dev: true
 
   /@types/eslint/7.2.14:
     resolution: {integrity: sha512-pESyhSbUOskqrGcaN+bCXIQDyT5zTaRWfj5ZjjSlMatgGjIn3QQPfocAu4WSabUR7CGyLZ2CQaZyISOEX7/saw==}
@@ -10393,6 +10375,7 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+    dev: true
 
   /@webassemblyjs/ast/1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -10406,6 +10389,7 @@ packages:
 
   /@webassemblyjs/floating-point-hex-parser/1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
+    dev: true
 
   /@webassemblyjs/floating-point-hex-parser/1.9.0:
     resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
@@ -10415,6 +10399,7 @@ packages:
 
   /@webassemblyjs/helper-api-error/1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
+    dev: true
 
   /@webassemblyjs/helper-api-error/1.9.0:
     resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
@@ -10424,6 +10409,7 @@ packages:
 
   /@webassemblyjs/helper-buffer/1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
+    dev: true
 
   /@webassemblyjs/helper-buffer/1.9.0:
     resolution: {integrity: sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==}
@@ -10454,12 +10440,14 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.1
       '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.0:
     resolution: {integrity: sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==}
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
+    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.9.0:
     resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
@@ -10479,6 +10467,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
+    dev: true
 
   /@webassemblyjs/helper-wasm-section/1.9.0:
     resolution: {integrity: sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==}
@@ -10497,6 +10486,7 @@ packages:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
+    dev: true
 
   /@webassemblyjs/ieee754/1.9.0:
     resolution: {integrity: sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==}
@@ -10512,6 +10502,7 @@ packages:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/leb128/1.9.0:
     resolution: {integrity: sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==}
@@ -10523,6 +10514,7 @@ packages:
 
   /@webassemblyjs/utf8/1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
+    dev: true
 
   /@webassemblyjs/utf8/1.9.0:
     resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
@@ -10550,6 +10542,7 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
       '@webassemblyjs/wast-printer': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-edit/1.9.0:
     resolution: {integrity: sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==}
@@ -10580,6 +10573,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-gen/1.9.0:
     resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
@@ -10605,6 +10599,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-opt/1.9.0:
     resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
@@ -10633,6 +10628,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-parser/1.9.0:
     resolution: {integrity: sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==}
@@ -10665,6 +10661,7 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/wast-printer/1.9.0:
     resolution: {integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==}
@@ -10691,6 +10688,7 @@ packages:
     dependencies:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+    dev: true
 
   /@webpack-cli/configtest/1.2.0_aa73yiufjzrs5dnjm4asji72by:
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
@@ -10725,7 +10723,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+      webpack-cli: 4.10.0_ptzbz4bao7we2onwdcwwuffqhy
 
   /@webpack-cli/serve/1.5.1_r5jz6ab5h5z5ui7vgheqnt6cae:
     resolution: {integrity: sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==}
@@ -10749,7 +10747,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+      webpack-cli: 4.10.0_webpack@5.39.1
 
   /@webpack-cli/serve/1.7.0_xcsigq56yu4htn6anmcckynncu:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -10868,6 +10866,7 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.7.1
+    dev: true
 
   /acorn-jsx/5.3.1_acorn@7.4.1:
     resolution: {integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==}
@@ -11149,6 +11148,13 @@ packages:
     dependencies:
       type-fest: 0.21.3
 
+  /ansi-escapes/5.0.0:
+    resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
+    engines: {node: '>=12'}
+    dependencies:
+      type-fest: 1.4.0
+    dev: true
+
   /ansi-html-community/0.0.8:
     resolution: {integrity: sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==}
     engines: {'0': node >= 0.8.0}
@@ -11200,6 +11206,11 @@ packages:
   /ansi-styles/5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  /ansi-styles/6.1.0:
+    resolution: {integrity: sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==}
+    engines: {node: '>=12'}
+    dev: true
 
   /ansi-to-html/0.6.15:
     resolution: {integrity: sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==}
@@ -11769,7 +11780,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.14.7
+      follow-redirects: 1.14.7_debug@4.3.3
     transitivePeerDependencies:
       - debug
 
@@ -12451,6 +12462,14 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
+  /bl/5.0.0:
+    resolution: {integrity: sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==}
+    dependencies:
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: true
+
   /blessed/0.1.81:
     resolution: {integrity: sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ==}
     engines: {node: '>= 0.8.0'}
@@ -12937,7 +12956,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -13211,6 +13230,11 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  /chalk/5.0.1:
+    resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -13464,11 +13488,23 @@ packages:
       restore-cursor: 3.1.0
     dev: true
 
+  /cli-cursor/4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      restore-cursor: 4.0.0
+    dev: true
+
   /cli-progress/3.11.2:
     resolution: {integrity: sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==}
     engines: {node: '>=4'}
     dependencies:
       string-width: 4.2.3
+
+  /cli-spinners/2.7.0:
+    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
+    engines: {node: '>=6'}
+    dev: true
 
   /cli-table3/0.6.2:
     resolution: {integrity: sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==}
@@ -13532,6 +13568,11 @@ packages:
 
   /cli-width/2.2.1:
     resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
+
+  /cli-width/4.0.0:
+    resolution: {integrity: sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==}
+    engines: {node: '>= 12'}
+    dev: true
 
   /clipboard-copy/3.2.0:
     resolution: {integrity: sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==}
@@ -13603,6 +13644,11 @@ packages:
     dependencies:
       mimic-response: 1.0.1
     dev: false
+
+  /clone/1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+    dev: true
 
   /clsx/1.1.1:
     resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
@@ -15134,6 +15180,12 @@ packages:
       execa: 1.0.0
       ip-regex: 2.1.0
 
+  /defaults/1.0.3:
+    resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
+    dependencies:
+      clone: 1.0.4
+    dev: true
+
   /defer-to-connect/1.1.3:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
     dev: false
@@ -15607,6 +15659,10 @@ packages:
       xtend: 4.0.2
     dev: false
 
+  /eastasianwidth/0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
+
   /ecdsa-sig-formatter/1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
@@ -15747,8 +15803,10 @@ packages:
       - supports-color
     dev: false
 
-  /electron-redux/1.5.4:
+  /electron-redux/1.5.4_redux@4.1.2:
     resolution: {integrity: sha512-7fM7OLVR34prk/ZlIv3yRbB4XCZPPQJ9ZfYLPmWPvKIONe2qm1e0on+cMLGgwzREapQrzCmc1VAxs8WNbWgncg==}
+    peerDependencies:
+      redux: ^4.0.1
     dependencies:
       debug: 4.3.3
       redux: 4.1.2
@@ -15855,7 +15913,6 @@ packages:
       '@emotion/weak-memoize': 0.2.5
       hoist-non-react-statics: 3.3.2
       react: 17.0.2
-    dev: true
 
   /emotion-theming/10.0.27_l4qwngn4rqpsicelhp3xw7f334:
     resolution: {integrity: sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==}
@@ -15910,6 +15967,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       tapable: 2.2.0
+    dev: true
 
   /enhanced-resolve/5.8.2:
     resolution: {integrity: sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==}
@@ -15999,6 +16057,7 @@ packages:
 
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+    dev: true
 
   /es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
@@ -16072,6 +16131,11 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  /escape-string-regexp/5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: true
 
   /escodegen/1.14.3:
     resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
@@ -17098,6 +17162,14 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
 
+  /figures/5.0.0:
+    resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
+    engines: {node: '>=14'}
+    dependencies:
+      escape-string-regexp: 5.0.0
+      is-unicode-supported: 1.2.0
+    dev: true
+
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -17405,7 +17477,7 @@ packages:
     resolution: {integrity: sha512-bHWEmjLsTjGP9gVs7P3Hyl+oY5NlMW8aTSPdTJ+X2GKt6glDctt9fUCLbRV+d/l8NDC40+FxMjp9WlTQXaQALw==}
     dev: false
 
-  /follow-redirects/1.14.7:
+  /follow-redirects/1.14.7_debug@4.3.3:
     resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -17413,6 +17485,8 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dependencies:
+      debug: 4.3.3_supports-color@6.1.0
 
   /follow-redirects/1.14.7_debug@4.3.4:
     resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
@@ -18770,7 +18844,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.7
+      follow-redirects: 1.14.7_debug@4.3.3
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -19115,6 +19189,27 @@ packages:
       strip-ansi: 5.2.0
       through: 2.3.8
 
+  /inquirer/9.1.1:
+    resolution: {integrity: sha512-hfS9EJ1pVkGNbYKqzdGwMj0Dqosd36Qvxd5pFy4657QT23gmtFTSqoYBisZR75DReeSMWPNa8J0Lf6TQCz8PvA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      ansi-escapes: 5.0.0
+      chalk: 5.0.1
+      cli-cursor: 4.0.0
+      cli-width: 4.0.0
+      external-editor: 3.1.0
+      figures: 5.0.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      ora: 6.1.2
+      run-async: 2.4.1
+      rxjs: 7.5.6
+      string-width: 5.1.2
+      strip-ansi: 7.0.1
+      through: 2.3.8
+      wrap-ansi: 8.0.1
+    dev: true
+
   /internal-ip/4.3.0:
     resolution: {integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==}
     engines: {node: '>=6'}
@@ -19403,6 +19498,11 @@ packages:
       is-path-inside: 3.0.3
     dev: false
 
+  /is-interactive/2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+    dev: true
+
   /is-lite/0.8.1:
     resolution: {integrity: sha512-ekSwuewzOmwFnzzAOWuA5fRFPqOeTrLIL3GWT7hdVVi+oLuD+Rau8gCmkb94vH5hjXc1Q/CfIW/y/td1RrNQIg==}
     dev: false
@@ -19602,6 +19702,11 @@ packages:
     dependencies:
       unc-path-regex: 0.1.2
     dev: false
+
+  /is-unicode-supported/1.2.0:
+    resolution: {integrity: sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ==}
+    engines: {node: '>=12'}
+    dev: true
 
   /is-url/1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
@@ -19946,7 +20051,7 @@ packages:
       '@jest/core': 27.4.7_ts-node@9.1.1
       '@jest/test-result': 27.4.6
       '@jest/types': 27.5.1
-      chalk: 4.1.1
+      chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.9
       import-local: 3.0.2
@@ -21907,6 +22012,14 @@ packages:
       chalk: 2.4.2
     dev: true
 
+  /log-symbols/5.1.0:
+    resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
+    engines: {node: '>=12'}
+    dependencies:
+      chalk: 5.0.1
+      is-unicode-supported: 1.2.0
+    dev: true
+
   /log-update/1.0.2:
     resolution: {integrity: sha512-4vSow8gbiGnwdDNrpy1dyNaXWKSCIPop0EHdE8GrnngHoJujM3QhvHUN/igsYCgPoHo7pFOezlJ61Hlln0KHyA==}
     engines: {node: '>=0.10.0'}
@@ -22123,16 +22236,6 @@ packages:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
     dev: true
 
-  /markdown-to-jsx/6.11.4_react@16.14.0:
-    resolution: {integrity: sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==}
-    engines: {node: '>= 4'}
-    peerDependencies:
-      react: '>= 0.14.0'
-    dependencies:
-      prop-types: 15.7.2
-      react: 16.14.0
-      unquote: 1.1.1
-
   /markdown-to-jsx/6.11.4_react@17.0.2:
     resolution: {integrity: sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==}
     engines: {node: '>= 4'}
@@ -22142,7 +22245,6 @@ packages:
       prop-types: 15.7.2
       react: 17.0.2
       unquote: 1.1.1
-    dev: true
 
   /marked/0.3.19:
     resolution: {integrity: sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==}
@@ -23214,15 +23316,13 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /next-purgecss/4.0.0:
+  /next-purgecss/4.0.0_webpack@4.46.0:
     resolution: {integrity: sha512-JrZTIvE1x9W1DNB/G4MkjMp5JYNdQnQmXb0qwIu341ETgwQ8FaboDzStREDaY4KK2aYY+jg+1mu7lCZ4FFe7NQ==}
     dependencies:
       glob-all: 3.1.0
-      purgecss-webpack-plugin: 2.1.0
+      purgecss-webpack-plugin: 2.1.0_webpack@4.46.0
     transitivePeerDependencies:
-      - supports-color
-      - webpack-cli
-      - webpack-command
+      - webpack
     dev: true
 
   /next-pwa/5.2.24_skj42vj5irkrz2icybc75wzw74:
@@ -23894,6 +23994,21 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
+
+  /ora/6.1.2:
+    resolution: {integrity: sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      bl: 5.0.0
+      chalk: 5.0.1
+      cli-cursor: 4.0.0
+      cli-spinners: 2.7.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 1.2.0
+      log-symbols: 5.1.0
+      strip-ansi: 7.0.1
+      wcwidth: 1.0.1
+    dev: true
 
   /original/1.0.2:
     resolution: {integrity: sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==}
@@ -25965,16 +26080,6 @@ packages:
       bluebird:
         optional: true
 
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
-
   /promise.allsettled/1.0.4:
     resolution: {integrity: sha512-o73CbvQh/OnPFShxHcHxk0baXR2a1m4ozb85ha0H14VEoi/EJJLa9mnPfEWJx9RjA9MLfhdjZ8I6HhWtBa64Ag==}
     engines: {node: '>= 0.4'}
@@ -26240,16 +26345,14 @@ packages:
       escape-goat: 2.1.1
     dev: false
 
-  /purgecss-webpack-plugin/2.1.0:
+  /purgecss-webpack-plugin/2.1.0_webpack@4.46.0:
     resolution: {integrity: sha512-zbcGmlQ/RwI3tIFegZKE0KhP/G9I+IUbEgQkwEF/xkj4MBLODgy5Vg3sV/B1iAKD2jAoyfWYH+TjPd5nVgGslw==}
+    peerDependencies:
+      webpack: '*'
     dependencies:
       purgecss: 2.3.0
       webpack: 4.46.0
       webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - supports-color
-      - webpack-cli
-      - webpack-command
     dev: true
 
   /purgecss/2.3.0:
@@ -26623,14 +26726,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-clientside-effect/1.2.5_react@16.14.0:
-    resolution: {integrity: sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==}
-    peerDependencies:
-      react: ^15.3.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@babel/runtime': 7.18.9
-      react: 16.14.0
-
   /react-clientside-effect/1.2.5_react@17.0.2:
     resolution: {integrity: sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==}
     peerDependencies:
@@ -26638,11 +26733,16 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.9
       react: 17.0.2
-    dev: false
 
   /react-dev-utils/11.0.4_4rd6kybsuzfgmdyllug52nrldq:
     resolution: {integrity: sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==}
     engines: {node: '>=10'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.10.4
       address: 1.1.2
@@ -26668,12 +26768,12 @@ packages:
       shell-quote: 1.7.2
       strip-ansi: 6.0.0
       text-table: 0.2.0
+      typescript: 4.3.5
+      webpack: 4.44.2
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
 
   /react-docgen-typescript-plugin/1.0.0_fh66qcvt6fztzjltdvxy4343yy:
     resolution: {integrity: sha512-Akc7EtryOA4d2yOX27B5ii+hyf/k15ymb01uB+VnRgtTAdfeDCmNPvyLbRJ6pRNYOuFlEBe1YfCH73bTPtpYVQ==}
@@ -26730,17 +26830,6 @@ packages:
       - supports-color
     dev: true
 
-  /react-dom/16.14.0_react@16.14.0:
-    resolution: {integrity: sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==}
-    peerDependencies:
-      react: ^16.14.0
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      prop-types: 15.7.2
-      react: 16.14.0
-      scheduler: 0.19.1
-
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
     peerDependencies:
@@ -26751,7 +26840,7 @@ packages:
       react: 17.0.2
       scheduler: 0.20.2
 
-  /react-element-to-jsx-string/14.3.2_zkbncb2mrwigeq3keybbaytzya:
+  /react-element-to-jsx-string/14.3.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-WZbvG72cjLXAxV7VOuSzuHEaI3RHj10DZu8EcKQpkKcAj7+qAkG5XUeSdX5FXrA0vPrlx0QsnAzZEBJwzV0e+w==}
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
@@ -26759,7 +26848,7 @@ packages:
     dependencies:
       '@base2/pretty-print-object': 1.0.0
       is-plain-object: 3.0.1
-      react: 16.14.0
+      react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
@@ -26816,7 +26905,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /react-focus-lock/2.5.2_nhp7wl2pwxhlzqos3czbs7ca5e:
+  /react-focus-lock/2.5.2_wl4y6gseskpemamwhbv27q43ni:
     resolution: {integrity: sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -26824,14 +26913,14 @@ packages:
       '@babel/runtime': 7.18.9
       focus-lock: 0.9.1
       prop-types: 15.7.2
-      react: 16.14.0
-      react-clientside-effect: 1.2.5_react@16.14.0
-      use-callback-ref: 1.3.0_nhp7wl2pwxhlzqos3czbs7ca5e
-      use-sidecar: 1.1.2_nhp7wl2pwxhlzqos3czbs7ca5e
+      react: 17.0.2
+      react-clientside-effect: 1.2.5_react@17.0.2
+      use-callback-ref: 1.3.0_wl4y6gseskpemamwhbv27q43ni
+      use-sidecar: 1.1.2_wl4y6gseskpemamwhbv27q43ni
     transitivePeerDependencies:
       - '@types/react'
 
-  /react-helmet-async/1.0.9_wcqkhtmu7mswc6yz4uyexck3ty:
+  /react-helmet-async/1.0.9_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-N+iUlo9WR3/u9qGMmP4jiYfaD6pe9IvDTapZLFJz2D3xlTlCM1Bzy4Ab3g72Nbajo/0ZyW+W9hdz8Hbe4l97pQ==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0
@@ -26840,8 +26929,8 @@ packages:
       '@babel/runtime': 7.18.9
       invariant: 2.2.4
       prop-types: 15.7.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       react-fast-compare: 3.2.0
       shallowequal: 1.1.0
 
@@ -26945,28 +27034,28 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-popper-tooltip/2.11.1_wcqkhtmu7mswc6yz4uyexck3ty:
+  /react-popper-tooltip/2.11.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-04A2f24GhyyMicKvg/koIOQ5BzlrRbKiAgP6L+Pdj1MVX3yJ1NeZ8+EidndQsbejFT55oW1b++wg2Z8KlAyhfQ==}
     peerDependencies:
       react: ^16.6.0
       react-dom: ^16.6.0
     dependencies:
       '@babel/runtime': 7.18.9
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
-      react-popper: 1.3.11_react@16.14.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-popper: 1.3.11_react@17.0.2
 
-  /react-popper/1.3.11_react@16.14.0:
+  /react-popper/1.3.11_react@17.0.2:
     resolution: {integrity: sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==}
     peerDependencies:
       react: 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.18.9
-      '@hypnosphi/create-react-context': 0.3.1_uutjjb2r36qagpytglxm7vtgnq
+      '@hypnosphi/create-react-context': 0.3.1_mv67koxdvxhyejehvpcoenu3ai
       deep-equal: 1.1.1
       popper.js: 1.16.1
       prop-types: 15.7.2
-      react: 16.14.0
+      react: 17.0.2
       typed-styles: 0.0.7
       warning: 4.0.3
 
@@ -27061,11 +27150,12 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-scripts/4.0.3_x42bqxgwliwa4f7rcvhhje7sti:
+  /react-scripts/4.0.3_e5z7iwxxkielgwr442hoaozk7u:
     resolution: {integrity: sha512-S5eO4vjUzUisvkIPB7jVsKtuH2HhWcASREYWHAQ1FP5HyCv3xgn+wpILAEWkmy+A+tTNbSZClhxjT3qz6g4L1A==}
     engines: {node: ^10.12.0 || >=12.0.0}
     hasBin: true
     peerDependencies:
+      eslint: '*'
       react: '>= 16'
       typescript: ^3.2.1 || ^4
     peerDependenciesMeta:
@@ -27210,7 +27300,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /react-syntax-highlighter/11.0.2_react@16.14.0:
+  /react-syntax-highlighter/11.0.2_react@17.0.2:
     resolution: {integrity: sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==}
     peerDependencies:
       react: '>= 0.14.0'
@@ -27219,7 +27309,7 @@ packages:
       highlight.js: 9.13.1
       lowlight: 1.11.0
       prismjs: 1.24.1
-      react: 16.14.0
+      react: 17.0.2
       refractor: 2.10.1
 
   /react-table/7.7.0_react@17.0.2:
@@ -27230,14 +27320,14 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-textarea-autosize/7.1.2_react@16.14.0:
+  /react-textarea-autosize/7.1.2_react@17.0.2:
     resolution: {integrity: sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==}
     peerDependencies:
       react: '>=0.14.0 <17.0.0'
     dependencies:
       '@babel/runtime': 7.18.9
       prop-types: 15.7.2
-      react: 16.14.0
+      react: 17.0.2
 
   /react-transition-group/4.4.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==}
@@ -28179,6 +28269,14 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
+  /restore-cursor/4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+    dev: true
+
   /ret/0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
@@ -28503,12 +28601,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xmlchars: 2.2.0
-
-  /scheduler/0.19.1:
-    resolution: {integrity: sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
 
   /scheduler/0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
@@ -28995,15 +29087,15 @@ packages:
     dependencies:
       is-arrayish: 0.3.2
 
-  /simplebar-react/1.2.3_wcqkhtmu7mswc6yz4uyexck3ty:
+  /simplebar-react/1.2.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==}
     peerDependencies:
       react: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
       react-dom: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
     dependencies:
       prop-types: 15.7.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       simplebar: 4.2.3
 
   /simplebar/4.2.3:
@@ -29543,6 +29635,15 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  /string-width/5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.0.1
+    dev: true
 
   /string.prototype.matchall/4.0.5:
     resolution: {integrity: sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==}
@@ -30423,6 +30524,7 @@ packages:
       source-map: 0.6.1
       terser: 5.13.1
       webpack: 5.73.0_webpack-cli@4.10.0
+    dev: true
 
   /terser-webpack-plugin/5.3.1_zjtckeea76d3oit4tw4tcptpni:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -31050,6 +31152,11 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
 
+  /type-fest/1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /type-is/1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -31219,6 +31326,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.5
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -31585,20 +31693,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /use-callback-ref/1.3.0_nhp7wl2pwxhlzqos3czbs7ca5e:
-    resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 17.0.14
-      react: 16.14.0
-      tslib: 2.4.0
-
   /use-callback-ref/1.3.0_wl4y6gseskpemamwhbv27q43ni:
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
     engines: {node: '>=10'}
@@ -31612,7 +31706,6 @@ packages:
       '@types/react': 17.0.14
       react: 17.0.2
       tslib: 2.4.0
-    dev: false
 
   /use-isomorphic-layout-effect/1.1.1_wl4y6gseskpemamwhbv27q43ni:
     resolution: {integrity: sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==}
@@ -31638,21 +31731,6 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /use-sidecar/1.1.2_nhp7wl2pwxhlzqos3czbs7ca5e:
-    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 17.0.14
-      detect-node-es: 1.1.0
-      react: 16.14.0
-      tslib: 2.4.0
-
   /use-sidecar/1.1.2_wl4y6gseskpemamwhbv27q43ni:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -31667,7 +31745,6 @@ packages:
       detect-node-es: 1.1.0
       react: 17.0.2
       tslib: 2.4.0
-    dev: false
 
   /use-subscription/1.5.1_react@17.0.2:
     resolution: {integrity: sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==}
@@ -31987,11 +32064,18 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.9
+    dev: true
 
   /wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
     dependencies:
       minimalistic-assert: 1.0.1
+
+  /wcwidth/1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+    dependencies:
+      defaults: 1.0.3
+    dev: true
 
   /web-namespaces/1.1.4:
     resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
@@ -32102,6 +32186,7 @@ packages:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.6.1
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-cli/4.10.0_ptzbz4bao7we2onwdcwwuffqhy:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
@@ -32546,6 +32631,7 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: true
 
   /webpack-virtual-modules/0.2.2:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
@@ -32912,6 +32998,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
@@ -33400,6 +33487,15 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  /wrap-ansi/8.0.1:
+    resolution: {integrity: sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.1.0
+      string-width: 5.1.2
+      strip-ansi: 7.0.1
+    dev: true
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,13 +85,14 @@ importers:
       glob: ^7.2.0
       husky: ^7.0.2
       ini: ^3.0.0
-      inquirer: ^9.1.0
+      inquirer: ^6.1.0
       jest: ^27.2.0
       jsonfile: ^6.1.0
       lint-staged: ^11.1.2
       localtunnel: ^2.0.2
       nock: ^13.2.4
       open: ^8.4.0
+      ora: ^5.0.0
       prettier: ^2.4.1
       replace-json-property: ^1.4.1
       semver: ^7.3.7
@@ -105,11 +106,7 @@ importers:
       webpack-bundle-size-analyzer: ^3.1.0
       webpack-cli: ^4.10.0
     dependencies:
-      '@statoscope/webpack-plugin': 5.24.0_webpack@5.73.0
-      cli-progress: 3.11.2
-      open: 8.4.0
-      webpack-bundle-analyzer: 4.6.1
-      webpack-bundle-size-analyzer: 3.1.0
+      ora: 5.4.1
     devDependencies:
       '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.16.7
       '@babel/preset-env': 7.18.9_@babel+core@7.16.7
@@ -117,6 +114,7 @@ importers:
       '@commitlint/cli': 13.2.1
       '@commitlint/config-conventional': 13.2.0
       '@commitlint/prompt': 13.2.1
+      '@statoscope/webpack-plugin': 5.24.0_webpack@5.73.0
       '@types/fs-extra': 9.0.13
       '@types/jest': 27.4.0
       '@types/node': 16.11.45
@@ -124,6 +122,7 @@ importers:
       axios-mock-adapter: 1.21.1_axios@0.25.0
       boxen: 5.1.2
       chalk: 4.1.1
+      cli-progress: 3.11.2
       cli-ux: 6.0.9
       codecov: 3.8.3
       command-exists: 1.2.9
@@ -135,12 +134,13 @@ importers:
       glob: 7.2.0
       husky: 7.0.4
       ini: 3.0.0
-      inquirer: 9.1.1
+      inquirer: 6.5.2
       jest: 27.4.7
       jsonfile: 6.1.0
       lint-staged: 11.2.6
       localtunnel: 2.0.2
       nock: 13.2.9
+      open: 8.4.0
       prettier: 2.7.1
       replace-json-property: 1.8.0
       semver: 7.3.7
@@ -150,6 +150,8 @@ importers:
       typescript: 4.3.5
       uuid: 8.3.2
       webpack: 5.73.0_webpack-cli@4.10.0
+      webpack-bundle-analyzer: 4.6.1
+      webpack-bundle-size-analyzer: 3.1.0
       webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
 
   packages/code-generator:
@@ -320,7 +322,7 @@ importers:
       eslint-plugin-react-hooks: 4.2.0_eslint@7.30.0
       jest: 27.4.7
       next-images: 1.8.1_webpack@4.46.0
-      next-purgecss: 4.0.0_webpack@4.46.0
+      next-purgecss: 4.0.0
       next-transpile-modules: 6.4.1
       prettier: 2.3.2
       prettier-plugin-tailwind: 2.2.12_oxaym2ms6qfncwedb32pv23thq
@@ -579,7 +581,7 @@ importers:
       '@radix-ui/react-context-menu': 1.0.0_fdan6bnjkwodef3etrqalnirem
       '@radix-ui/react-icons': 1.1.1_react@17.0.2
       '@stitches/react': 1.2.8_react@17.0.2
-      '@storybook/addon-info': 5.3.21_iyxxhekejclwcqxm4p27oyqaq4
+      '@storybook/addon-info': 5.3.21_kpnaldxznq4w6o534bf4fb74au
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react': 11.2.7_sfoxds7t5ydpegc3knd667wn6m
       '@testing-library/user-event': 12.8.3_7izb363m7fjrh7ob6q4a2yqaqe
@@ -593,7 +595,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-joyride: 2.3.2_tpowlqvwbtughbcexafts2sidm
-      react-scripts: 4.0.3_e5z7iwxxkielgwr442hoaozk7u
+      react-scripts: 4.0.3_x42bqxgwliwa4f7rcvhhje7sti
       storybook-addon-designs: 6.3.1_react@17.0.2
       tailwindcss: /@tailwindcss/postcss7-compat/2.2.17
       typescript: 4.3.5
@@ -783,7 +785,7 @@ importers:
       electron-debug: 3.2.0
       electron-devtools-installer: 3.2.0
       electron-notarize: 1.1.1
-      electron-redux: 1.5.4_redux@4.1.2
+      electron-redux: 1.5.4
       electron-updater: 4.6.1
       electron-window-state: 5.0.3
       event-kit: 2.5.3
@@ -3861,12 +3863,12 @@ packages:
   /@discoveryjs/json-ext/0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
-    dev: false
+    dev: true
 
   /@discoveryjs/natural-compare/1.0.0:
     resolution: {integrity: sha512-Pq35vJMxLZq4whZhyaMGO/89mmFee2+6NojaXD2bNo+7CxI6P7C1tncgQ0CM60+WueRMr8uFDKSX/8KitImCQg==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
-    dev: false
+    dev: true
 
   /@electron/get/1.12.4:
     resolution: {integrity: sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==}
@@ -4135,6 +4137,7 @@ packages:
       '@emotion/serialize': 0.11.16
       '@emotion/utils': 0.11.3
       react: 17.0.2
+    dev: true
 
   /@emotion/styled-base/10.0.31_l4qwngn4rqpsicelhp3xw7f334:
     resolution: {integrity: sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==}
@@ -4159,6 +4162,7 @@ packages:
       '@emotion/styled-base': 10.0.31_go5tdyoyk4iceqw7gzblglw2da
       babel-plugin-emotion: 10.2.2
       react: 17.0.2
+    dev: true
 
   /@emotion/styled/10.0.27_l4qwngn4rqpsicelhp3xw7f334:
     resolution: {integrity: sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==}
@@ -4463,7 +4467,7 @@ packages:
   /@humanwhocodes/object-schema/1.2.0:
     resolution: {integrity: sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==}
 
-  /@hypnosphi/create-react-context/0.3.1_mv67koxdvxhyejehvpcoenu3ai:
+  /@hypnosphi/create-react-context/0.3.1_uutjjb2r36qagpytglxm7vtgnq:
     resolution: {integrity: sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==}
     peerDependencies:
       prop-types: ^15.0.0
@@ -4471,7 +4475,7 @@ packages:
     dependencies:
       gud: 1.0.0
       prop-types: 15.7.2
-      react: 17.0.2
+      react: 16.14.0
       warning: 4.0.3
 
   /@istanbuljs/load-nyc-config/1.1.0:
@@ -5585,6 +5589,7 @@ packages:
 
   /@polka/url/1.0.0-next.15:
     resolution: {integrity: sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==}
+    dev: true
 
   /@popperjs/core/2.9.2:
     resolution: {integrity: sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==}
@@ -7637,7 +7642,7 @@ packages:
 
   /@statoscope/extensions/5.14.1:
     resolution: {integrity: sha512-5O31566+bOkkdYFH81mGGBTh0YcU0zoYurTrsK5uZfpNY87ZCPpptrszX8npTRHNsxbjBBNt7vAwImJyYdhzLw==}
-    dev: false
+    dev: true
 
   /@statoscope/helpers/5.24.0:
     resolution: {integrity: sha512-PhCynDA+FHB1DuuHlMeVnETRRDfgKrQTGey2jhBdHzd/Gae/GuwDcnFxiRVMIA97UQM8EwyE/hc0sF6dpPXd9w==}
@@ -7647,20 +7652,20 @@ packages:
       archy: 1.0.0
       jora: 1.0.0-beta.7
       semver: 7.3.7
-    dev: false
+    dev: true
 
   /@statoscope/report-writer/5.22.0:
     resolution: {integrity: sha512-oEIlfsMSwBM8PcHnHDwhgMz5fyDgu10oAVFwuQSJFBUXMwaZ/46ewr1kfAcUNc8CkOIolhO6EIo/e0ZjcVCR1g==}
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-    dev: false
+    dev: true
 
   /@statoscope/stats-extension-compressed/5.24.0:
     resolution: {integrity: sha512-QRgTY7wnJhB5BjV2OHt2e3E8rLi+53LEJ2q7KZDjRMNZNGY6G1LPIuHTCAUlcLNxDbaeATqkioTVRyf2v9SjPQ==}
     dependencies:
       '@statoscope/helpers': 5.24.0
       gzip-size: 6.0.0
-    dev: false
+    dev: true
 
   /@statoscope/stats-extension-custom-reports/5.24.0:
     resolution: {integrity: sha512-n20dL3WYrwla8eCYNtHY0AdcBuyHiaW1F2gQBsJqV3PJzIYBijo/f1dHl2p8hzVDQmJ/QYWNwsbTvr1GQGdseg==}
@@ -7669,13 +7674,13 @@ packages:
       '@statoscope/helpers': 5.24.0
       '@statoscope/stats': 5.14.1
       '@statoscope/types': 5.22.0
-    dev: false
+    dev: true
 
   /@statoscope/stats-extension-package-info/5.24.0:
     resolution: {integrity: sha512-L7UtVb5CwG2dMZdVrGjok4+0ryEASO1rr8Kf/QzcQNIHb8mG5VSYRFBlcFfvvC/PNKafxoexbwhiSGZEtggwqw==}
     dependencies:
       '@statoscope/helpers': 5.24.0
-    dev: false
+    dev: true
 
   /@statoscope/stats-extension-stats-validation-result/5.24.0:
     resolution: {integrity: sha512-++8hX2cb0CpIM+gqLwIl9N/ISJHTKtrQXwsl9CSlds3K4D49BwC2cULlvhGdjVRMf7U1RI0COL9dj79K7iK5Ig==}
@@ -7684,17 +7689,17 @@ packages:
       '@statoscope/helpers': 5.24.0
       '@statoscope/stats': 5.14.1
       '@statoscope/types': 5.22.0
-    dev: false
+    dev: true
 
   /@statoscope/stats/5.14.1:
     resolution: {integrity: sha512-Kz7kCKuT6DXaqAPfyTwp27xHMDUna9o6UlRSQXXBZ8Yyk7eYYvTNw+5ffRyqivL9IOzD7FQYDQ6VUBHh0UfyDw==}
-    dev: false
+    dev: true
 
   /@statoscope/types/5.22.0:
     resolution: {integrity: sha512-FHgunU7M95v7c71pvQ2nr8bWy1QcTDOHSnkoFQErORH9RmxlK9oRkoWrO8BJpnxa55m/9ZHjFVmpLF4SsVGHoA==}
     dependencies:
       '@statoscope/stats': 5.14.1
-    dev: false
+    dev: true
 
   /@statoscope/webpack-model/5.24.0:
     resolution: {integrity: sha512-6XHhTbA4Vw8LKUGLuRvsNUUgiiGAvqciUMQRjovf2xNRT2a3rCP7L3QKOntEvIBcKzNGuQ0T+L5sKF8pqiI3mA==}
@@ -7708,7 +7713,7 @@ packages:
       '@statoscope/stats-extension-stats-validation-result': 5.24.0
       '@statoscope/types': 5.22.0
       md5: 2.3.0
-    dev: false
+    dev: true
 
   /@statoscope/webpack-plugin/5.24.0_webpack@5.73.0:
     resolution: {integrity: sha512-8GX0ULmvwZRAqQClLMdzV1L/Y9PBJZTwBTXiiKzU4+vypRiI7VA+fz9aZ2XGWErVonXbrIvclj2IAQMbz/z2YQ==}
@@ -7727,7 +7732,7 @@ packages:
       '@statoscope/webpack-ui': 5.24.0
       open: 8.4.0
       webpack: 5.73.0_webpack-cli@4.10.0
-    dev: false
+    dev: true
 
   /@statoscope/webpack-stats-extension-compressed/5.24.0_webpack@5.73.0:
     resolution: {integrity: sha512-yJyYo/TC393MZcA/txnd/37WubSdGNpVAncFlifVtJoGgsD9GrqltN8aUiaVPBDy/r4N4qP9+8T6OQ/Ha4J4DA==}
@@ -7738,7 +7743,7 @@ packages:
       '@statoscope/stats-extension-compressed': 5.24.0
       '@statoscope/webpack-model': 5.24.0
       webpack: 5.73.0_webpack-cli@4.10.0
-    dev: false
+    dev: true
 
   /@statoscope/webpack-stats-extension-package-info/5.24.0_webpack@5.73.0:
     resolution: {integrity: sha512-AXtYSbvyyFdgn1H/bnE2gu0oEhKBiHbeZA/gCJM+hEWOwGWnz61+qiPxYj2QnOnXN8XmjHho3jf0Gd4eW3dJfw==}
@@ -7749,13 +7754,13 @@ packages:
       '@statoscope/stats-extension-package-info': 5.24.0
       '@statoscope/webpack-model': 5.24.0
       webpack: 5.73.0_webpack-cli@4.10.0
-    dev: false
+    dev: true
 
   /@statoscope/webpack-ui/5.24.0:
     resolution: {integrity: sha512-tqNH1O7WE8dVa2WknmmM4j7mYD6mna3TKRLRYmiAwg6W/RICVAxXwZy1v9uKN9+pfa6By0hI3mWiYS7V1seh2w==}
     dependencies:
       '@statoscope/types': 5.22.0
-    dev: false
+    dev: true
 
   /@stitches/react/1.2.8_react@17.0.2:
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
@@ -8002,23 +8007,21 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-info/5.3.21_iyxxhekejclwcqxm4p27oyqaq4:
+  /@storybook/addon-info/5.3.21_kpnaldxznq4w6o534bf4fb74au:
     resolution: {integrity: sha512-A/K9HzmoXMuOUxH3AozTvjNZwTlYVHob2OaDRfMza0gYMzG0tOrxqcdNTigeAWAjS//Z0G3enue6rHulQZK/+g==}
-    peerDependencies:
-      react: '*'
     dependencies:
       '@storybook/addons': 5.3.21_tywxhxqgoy4ic6dja7arbokhba
       '@storybook/client-logger': 5.3.21
-      '@storybook/components': 5.3.21_fdan6bnjkwodef3etrqalnirem
-      '@storybook/theming': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/components': 5.3.21_@types+react@17.0.14
+      '@storybook/theming': 5.3.21_zkbncb2mrwigeq3keybbaytzya
       core-js: 3.15.2
       global: 4.4.0
       marksy: 8.0.0
       nested-object-assign: 1.0.4
       prop-types: 15.7.2
-      react: 17.0.2
+      react: 16.14.0
       react-addons-create-fragment: 15.6.2
-      react-element-to-jsx-string: 14.3.2_sfoxds7t5ydpegc3knd667wn6m
+      react-element-to-jsx-string: 14.3.2_zkbncb2mrwigeq3keybbaytzya
       react-is: 16.13.1
       react-lifecycles-compat: 3.0.4
       util-deprecate: 1.0.2
@@ -8086,7 +8089,7 @@ packages:
       '@storybook/addons': 5.3.21_tywxhxqgoy4ic6dja7arbokhba
       '@storybook/api': 5.3.21_tywxhxqgoy4ic6dja7arbokhba
       '@storybook/client-logger': 5.3.21
-      '@storybook/components': 5.3.21_fdan6bnjkwodef3etrqalnirem
+      '@storybook/components': 5.3.21_@types+react@17.0.14
       '@storybook/core-events': 5.3.21
       '@storybook/router': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/theming': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
@@ -8409,32 +8412,29 @@ packages:
       core-js: 3.15.2
       global: 4.4.0
 
-  /@storybook/components/5.3.21_fdan6bnjkwodef3etrqalnirem:
+  /@storybook/components/5.3.21_@types+react@17.0.14:
     resolution: {integrity: sha512-42QQk6qZl6wrtajP8yNCfmNS2t8Iod5QY+4V/l6iNnnT9O+j6cWOlnO+ZyvjNv0Xm0zIOt+VyVjdkKh8FUjQmA==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
     dependencies:
       '@storybook/client-logger': 5.3.21
-      '@storybook/theming': 5.3.21_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 5.3.21_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/react-syntax-highlighter': 11.0.4
       '@types/react-textarea-autosize': 4.3.6
       core-js: 3.15.2
       global: 4.4.0
       lodash: 4.17.21
-      markdown-to-jsx: 6.11.4_react@17.0.2
+      markdown-to-jsx: 6.11.4_react@16.14.0
       memoizerific: 1.11.3
       polished: 3.7.2
       popper.js: 1.16.1
       prop-types: 15.7.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-focus-lock: 2.5.2_wl4y6gseskpemamwhbv27q43ni
-      react-helmet-async: 1.0.9_sfoxds7t5ydpegc3knd667wn6m
-      react-popper-tooltip: 2.11.1_sfoxds7t5ydpegc3knd667wn6m
-      react-syntax-highlighter: 11.0.2_react@17.0.2
-      react-textarea-autosize: 7.1.2_react@17.0.2
-      simplebar-react: 1.2.3_sfoxds7t5ydpegc3knd667wn6m
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      react-focus-lock: 2.5.2_nhp7wl2pwxhlzqos3czbs7ca5e
+      react-helmet-async: 1.0.9_wcqkhtmu7mswc6yz4uyexck3ty
+      react-popper-tooltip: 2.11.1_wcqkhtmu7mswc6yz4uyexck3ty
+      react-syntax-highlighter: 11.0.2_react@16.14.0
+      react-textarea-autosize: 7.1.2_react@16.14.0
+      simplebar-react: 1.2.3_wcqkhtmu7mswc6yz4uyexck3ty
       ts-dedent: 1.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -8886,7 +8886,7 @@ packages:
       babel-plugin-react-docgen: 4.2.1
       pnp-webpack-plugin: 1.6.4_typescript@4.3.5
       react-docgen-typescript-plugin: 1.0.0_fh66qcvt6fztzjltdvxy4343yy
-      react-scripts: 4.0.3_e5z7iwxxkielgwr442hoaozk7u
+      react-scripts: 4.0.3_x42bqxgwliwa4f7rcvhhje7sti
       semver: 7.3.5
     transitivePeerDependencies:
       - react-refresh
@@ -9184,6 +9184,28 @@ packages:
       prop-types: 15.7.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      resolve-from: 5.0.0
+      ts-dedent: 1.2.0
+    dev: true
+
+  /@storybook/theming/5.3.21_wcqkhtmu7mswc6yz4uyexck3ty:
+    resolution: {integrity: sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      '@emotion/core': 10.1.1_react@16.14.0
+      '@emotion/styled': 10.0.27_l4qwngn4rqpsicelhp3xw7f334
+      '@storybook/client-logger': 5.3.21
+      core-js: 3.15.2
+      deep-object-diff: 1.1.0
+      emotion-theming: 10.0.27_l4qwngn4rqpsicelhp3xw7f334
+      global: 4.4.0
+      memoizerific: 1.11.3
+      polished: 3.7.2
+      prop-types: 15.7.2
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
       resolve-from: 5.0.0
       ts-dedent: 1.2.0
 
@@ -9666,7 +9688,7 @@ packages:
 
   /@types/archy/0.0.32:
     resolution: {integrity: sha512-5ZZ5+YGmUE01yejiXsKnTcvhakMZ2UllZlMsQni53Doc1JWhe21ia8VntRoRD6fAEWw08JBh/z9qQHJ+//MrIg==}
-    dev: false
+    dev: true
 
   /@types/aria-query/4.2.2:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
@@ -9799,6 +9821,7 @@ packages:
     dependencies:
       '@types/eslint': 7.2.14
       '@types/estree': 0.0.51
+    dev: true
 
   /@types/eslint/7.2.14:
     resolution: {integrity: sha512-pESyhSbUOskqrGcaN+bCXIQDyT5zTaRWfj5ZjjSlMatgGjIn3QQPfocAu4WSabUR7CGyLZ2CQaZyISOEX7/saw==}
@@ -10233,7 +10256,7 @@ packages:
 
   /@types/semver/7.3.12:
     resolution: {integrity: sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==}
-    dev: false
+    dev: true
 
   /@types/semver/7.3.9:
     resolution: {integrity: sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==}
@@ -10518,6 +10541,7 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+    dev: true
 
   /@webassemblyjs/ast/1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -10531,6 +10555,7 @@ packages:
 
   /@webassemblyjs/floating-point-hex-parser/1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
+    dev: true
 
   /@webassemblyjs/floating-point-hex-parser/1.9.0:
     resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
@@ -10540,6 +10565,7 @@ packages:
 
   /@webassemblyjs/helper-api-error/1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
+    dev: true
 
   /@webassemblyjs/helper-api-error/1.9.0:
     resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
@@ -10549,6 +10575,7 @@ packages:
 
   /@webassemblyjs/helper-buffer/1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
+    dev: true
 
   /@webassemblyjs/helper-buffer/1.9.0:
     resolution: {integrity: sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==}
@@ -10579,12 +10606,14 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.1
       '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.0:
     resolution: {integrity: sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==}
 
   /@webassemblyjs/helper-wasm-bytecode/1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
+    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode/1.9.0:
     resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
@@ -10604,6 +10633,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
+    dev: true
 
   /@webassemblyjs/helper-wasm-section/1.9.0:
     resolution: {integrity: sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==}
@@ -10622,6 +10652,7 @@ packages:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
+    dev: true
 
   /@webassemblyjs/ieee754/1.9.0:
     resolution: {integrity: sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==}
@@ -10637,6 +10668,7 @@ packages:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/leb128/1.9.0:
     resolution: {integrity: sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==}
@@ -10648,6 +10680,7 @@ packages:
 
   /@webassemblyjs/utf8/1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
+    dev: true
 
   /@webassemblyjs/utf8/1.9.0:
     resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
@@ -10675,6 +10708,7 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
       '@webassemblyjs/wast-printer': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-edit/1.9.0:
     resolution: {integrity: sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==}
@@ -10705,6 +10739,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-gen/1.9.0:
     resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
@@ -10730,6 +10765,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-opt/1.9.0:
     resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
@@ -10758,6 +10794,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-parser/1.9.0:
     resolution: {integrity: sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==}
@@ -10790,6 +10827,7 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/wast-printer/1.9.0:
     resolution: {integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==}
@@ -10816,6 +10854,7 @@ packages:
     dependencies:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+    dev: true
 
   /@webpack-cli/configtest/1.2.0_aa73yiufjzrs5dnjm4asji72by:
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
@@ -10850,7 +10889,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+      webpack-cli: 4.10.0_ptzbz4bao7we2onwdcwwuffqhy
 
   /@webpack-cli/serve/1.5.1_r5jz6ab5h5z5ui7vgheqnt6cae:
     resolution: {integrity: sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==}
@@ -10874,7 +10913,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_bco76sj2s6hhm5n6qzmeypcd64
+      webpack-cli: 4.10.0_webpack@5.39.1
 
   /@webpack-cli/serve/1.7.0_xcsigq56yu4htn6anmcckynncu:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -10993,6 +11032,7 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.7.1
+    dev: true
 
   /acorn-jsx/5.3.1_acorn@7.4.1:
     resolution: {integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==}
@@ -11123,10 +11163,8 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -11274,13 +11312,6 @@ packages:
     dependencies:
       type-fest: 0.21.3
 
-  /ansi-escapes/5.0.0:
-    resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
-    engines: {node: '>=12'}
-    dependencies:
-      type-fest: 1.4.0
-    dev: true
-
   /ansi-html-community/0.0.8:
     resolution: {integrity: sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==}
     engines: {'0': node >= 0.8.0}
@@ -11333,11 +11364,6 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  /ansi-styles/6.1.0:
-    resolution: {integrity: sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==}
-    engines: {node: '>=12'}
-    dev: true
-
   /ansi-to-html/0.6.15:
     resolution: {integrity: sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==}
     engines: {node: '>=8.0.0'}
@@ -11386,10 +11412,10 @@ packages:
     resolution: {integrity: sha512-Bxn8U3KIVthgBVXN//hgF6gD+LPHwXl/pcoKxVR64JlyMKdcrmpFssahO71O07RLEZnXzcwBXh4qIjK74xJ/bw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      7zip-bin: 5.1.1
       '@develar/schema-utils': 2.6.5
       '@electron/universal': 1.2.1
       '@malept/flatpak-bundler': 0.4.0
+      7zip-bin: 5.1.1
       async-exit-hook: 2.0.1
       bluebird-lst: 1.0.9
       builder-util: 23.3.0
@@ -11473,6 +11499,7 @@ packages:
 
   /archy/1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
+    dev: true
 
   /are-we-there-yet/2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
@@ -12587,14 +12614,6 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
-  /bl/5.0.0:
-    resolution: {integrity: sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==}
-    dependencies:
-      buffer: 6.0.3
-      inherits: 2.0.4
-      readable-stream: 3.6.0
-    dev: true
-
   /blessed/0.1.81:
     resolution: {integrity: sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ==}
     engines: {node: '>= 0.8.0'}
@@ -12980,9 +12999,9 @@ packages:
   /builder-util/23.3.0:
     resolution: {integrity: sha512-m7RRd21N2yrnuGFd+ZqOY0ryeqWmBslDKmGDVz0wETqoEEqpiJsF3CGlsb6MRN2EQKDubvE5e+lBf8ATt06fnA==}
     dependencies:
-      7zip-bin: 5.1.1
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
+      7zip-bin: 5.1.1
       app-builder-bin: 4.0.0
       bluebird-lst: 1.0.9
       builder-util-runtime: 9.0.3
@@ -13081,7 +13100,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -13355,11 +13374,6 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  /chalk/5.0.1:
-    resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: true
-
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -13387,7 +13401,6 @@ packages:
 
   /charenc/0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-    dev: false
 
   /charm/0.1.2:
     resolution: {integrity: sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==}
@@ -13611,14 +13624,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       restore-cursor: 3.1.0
-    dev: true
-
-  /cli-cursor/4.0.0:
-    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      restore-cursor: 4.0.0
-    dev: true
 
   /cli-progress/3.11.2:
     resolution: {integrity: sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==}
@@ -13629,7 +13634,7 @@ packages:
   /cli-spinners/2.7.0:
     resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
     engines: {node: '>=6'}
-    dev: true
+    dev: false
 
   /cli-table3/0.6.2:
     resolution: {integrity: sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==}
@@ -13693,11 +13698,6 @@ packages:
 
   /cli-width/2.2.1:
     resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
-
-  /cli-width/4.0.0:
-    resolution: {integrity: sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==}
-    engines: {node: '>= 12'}
-    dev: true
 
   /clipboard-copy/3.2.0:
     resolution: {integrity: sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==}
@@ -13773,7 +13773,7 @@ packages:
   /clone/1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-    dev: true
+    dev: false
 
   /clsx/1.1.1:
     resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
@@ -14201,8 +14201,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.0.0
@@ -14573,7 +14573,6 @@ packages:
 
   /crypt/0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
-    dev: false
 
   /crypto-browserify/3.12.0:
     resolution: {integrity: sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==}
@@ -15309,7 +15308,7 @@ packages:
     resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
     dependencies:
       clone: 1.0.4
-    dev: true
+    dev: false
 
   /defer-to-connect/1.1.3:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
@@ -15323,6 +15322,7 @@ packages:
   /define-lazy-prop/2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+    dev: true
 
   /define-properties/1.1.3:
     resolution: {integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==}
@@ -15784,10 +15784,6 @@ packages:
       xtend: 4.0.2
     dev: false
 
-  /eastasianwidth/0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
-
   /ecdsa-sig-formatter/1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
@@ -15928,10 +15924,8 @@ packages:
       - supports-color
     dev: false
 
-  /electron-redux/1.5.4_redux@4.1.2:
+  /electron-redux/1.5.4:
     resolution: {integrity: sha512-7fM7OLVR34prk/ZlIv3yRbB4XCZPPQJ9ZfYLPmWPvKIONe2qm1e0on+cMLGgwzREapQrzCmc1VAxs8WNbWgncg==}
-    peerDependencies:
-      redux: ^4.0.1
     dependencies:
       debug: 4.3.3
       redux: 4.1.2
@@ -16038,6 +16032,7 @@ packages:
       '@emotion/weak-memoize': 0.2.5
       hoist-non-react-statics: 3.3.2
       react: 17.0.2
+    dev: true
 
   /emotion-theming/10.0.27_l4qwngn4rqpsicelhp3xw7f334:
     resolution: {integrity: sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==}
@@ -16092,6 +16087,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.9
       tapable: 2.2.0
+    dev: true
 
   /enhanced-resolve/5.8.2:
     resolution: {integrity: sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==}
@@ -16181,6 +16177,7 @@ packages:
 
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+    dev: true
 
   /es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
@@ -16254,11 +16251,6 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  /escape-string-regexp/5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
-    dev: true
 
   /escodegen/1.14.3:
     resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
@@ -17285,14 +17277,6 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  /figures/5.0.0:
-    resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
-    engines: {node: '>=14'}
-    dependencies:
-      escape-string-regexp: 5.0.0
-      is-unicode-supported: 1.2.0
-    dev: true
-
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -17362,7 +17346,7 @@ packages:
   /filesize/3.6.1:
     resolution: {integrity: sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==}
     engines: {node: '>= 0.4.0'}
-    dev: false
+    dev: true
 
   /filesize/6.1.0:
     resolution: {integrity: sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==}
@@ -17613,17 +17597,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.14.7_debug@4.3.3:
-    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.3_supports-color@6.1.0
 
   /follow-redirects/1.14.7_debug@4.3.4:
     resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
@@ -18500,6 +18473,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       duplexer: 0.1.2
+    dev: true
 
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -18981,7 +18955,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.7_debug@4.3.3
+      follow-redirects: 1.14.7
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -19035,7 +19009,7 @@ packages:
 
   /humanize/0.0.9:
     resolution: {integrity: sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q==}
-    dev: false
+    dev: true
 
   /husky/6.0.0:
     resolution: {integrity: sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==}
@@ -19330,27 +19304,6 @@ packages:
       strip-ansi: 5.2.0
       through: 2.3.8
 
-  /inquirer/9.1.1:
-    resolution: {integrity: sha512-hfS9EJ1pVkGNbYKqzdGwMj0Dqosd36Qvxd5pFy4657QT23gmtFTSqoYBisZR75DReeSMWPNa8J0Lf6TQCz8PvA==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      ansi-escapes: 5.0.0
-      chalk: 5.0.1
-      cli-cursor: 4.0.0
-      cli-width: 4.0.0
-      external-editor: 3.1.0
-      figures: 5.0.0
-      lodash: 4.17.21
-      mute-stream: 0.0.8
-      ora: 6.1.2
-      run-async: 2.4.1
-      rxjs: 7.5.6
-      string-width: 5.1.2
-      strip-ansi: 7.0.1
-      through: 2.3.8
-      wrap-ansi: 8.0.1
-    dev: true
-
   /internal-ip/4.3.0:
     resolution: {integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==}
     engines: {node: '>=6'}
@@ -19639,10 +19592,10 @@ packages:
       is-path-inside: 3.0.3
     dev: false
 
-  /is-interactive/2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
-    dev: true
+  /is-interactive/1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+    dev: false
 
   /is-lite/0.8.1:
     resolution: {integrity: sha512-ekSwuewzOmwFnzzAOWuA5fRFPqOeTrLIL3GWT7hdVVi+oLuD+Rau8gCmkb94vH5hjXc1Q/CfIW/y/td1RrNQIg==}
@@ -19844,10 +19797,10 @@ packages:
       unc-path-regex: 0.1.2
     dev: false
 
-  /is-unicode-supported/1.2.0:
-    resolution: {integrity: sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ==}
-    engines: {node: '>=12'}
-    dev: true
+  /is-unicode-supported/0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /is-url/1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
@@ -21142,7 +21095,7 @@ packages:
     engines: {node: ^10.12.0 || ^12.20.0 || ^14.13.0 || >=15.0.0}
     dependencies:
       '@discoveryjs/natural-compare': 1.0.0
-    dev: false
+    dev: true
 
   /jotai/1.4.7_taaswbfv5gpjqrwqwdhq6newyu:
     resolution: {integrity: sha512-EZFmhovnufIVoH0OAW6kuOv8RLjCX2HvHEqzwRG79l/LDeyp1BI+85vrEpR/fQmqh3jUhY4SyjhboEItd4+reQ==}
@@ -22160,13 +22113,13 @@ packages:
       chalk: 2.4.2
     dev: true
 
-  /log-symbols/5.1.0:
-    resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
-    engines: {node: '>=12'}
+  /log-symbols/4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
     dependencies:
-      chalk: 5.0.1
-      is-unicode-supported: 1.2.0
-    dev: true
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+    dev: false
 
   /log-update/1.0.2:
     resolution: {integrity: sha512-4vSow8gbiGnwdDNrpy1dyNaXWKSCIPop0EHdE8GrnngHoJujM3QhvHUN/igsYCgPoHo7pFOezlJ61Hlln0KHyA==}
@@ -22384,6 +22337,16 @@ packages:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
     dev: true
 
+  /markdown-to-jsx/6.11.4_react@16.14.0:
+    resolution: {integrity: sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==}
+    engines: {node: '>= 4'}
+    peerDependencies:
+      react: '>= 0.14.0'
+    dependencies:
+      prop-types: 15.7.2
+      react: 16.14.0
+      unquote: 1.1.1
+
   /markdown-to-jsx/6.11.4_react@17.0.2:
     resolution: {integrity: sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==}
     engines: {node: '>= 4'}
@@ -22393,6 +22356,7 @@ packages:
       prop-types: 15.7.2
       react: 17.0.2
       unquote: 1.1.1
+    dev: true
 
   /marked/0.3.19:
     resolution: {integrity: sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==}
@@ -22433,7 +22397,6 @@ packages:
       charenc: 0.0.2
       crypt: 0.0.2
       is-buffer: 1.1.6
-    dev: false
 
   /mdast-comment-marker/2.1.0:
     resolution: {integrity: sha512-/+Cfm8A83PjkqjQDB9iYqHESGuXlriCWAwRGPJjkYmxXrF4r6saxeUlOKNrf+SogTwg9E8uyHRCFHLG6/BAAdA==}
@@ -23464,13 +23427,15 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /next-purgecss/4.0.0_webpack@4.46.0:
+  /next-purgecss/4.0.0:
     resolution: {integrity: sha512-JrZTIvE1x9W1DNB/G4MkjMp5JYNdQnQmXb0qwIu341ETgwQ8FaboDzStREDaY4KK2aYY+jg+1mu7lCZ4FFe7NQ==}
     dependencies:
       glob-all: 3.1.0
-      purgecss-webpack-plugin: 2.1.0_webpack@4.46.0
+      purgecss-webpack-plugin: 2.1.0
     transitivePeerDependencies:
-      - webpack
+      - supports-color
+      - webpack-cli
+      - webpack-command
     dev: true
 
   /next-pwa/5.2.24_skj42vj5irkrz2icybc75wzw74:
@@ -24087,6 +24052,7 @@ packages:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+    dev: true
 
   /openapi3-ts/2.0.2:
     resolution: {integrity: sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==}
@@ -24097,6 +24063,7 @@ packages:
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
+    dev: true
 
   /openurl/1.1.1:
     resolution: {integrity: sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==}
@@ -24143,20 +24110,20 @@ packages:
       type-check: 0.4.0
       word-wrap: 1.2.3
 
-  /ora/6.1.2:
-    resolution: {integrity: sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  /ora/5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
     dependencies:
-      bl: 5.0.0
-      chalk: 5.0.1
-      cli-cursor: 4.0.0
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
       cli-spinners: 2.7.0
-      is-interactive: 2.0.0
-      is-unicode-supported: 1.2.0
-      log-symbols: 5.1.0
-      strip-ansi: 7.0.1
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
       wcwidth: 1.0.1
-    dev: true
+    dev: false
 
   /original/1.0.2:
     resolution: {integrity: sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==}
@@ -26228,6 +26195,16 @@ packages:
       bluebird:
         optional: true
 
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
+
   /promise.allsettled/1.0.4:
     resolution: {integrity: sha512-o73CbvQh/OnPFShxHcHxk0baXR2a1m4ozb85ha0H14VEoi/EJJLa9mnPfEWJx9RjA9MLfhdjZ8I6HhWtBa64Ag==}
     engines: {node: '>= 0.4'}
@@ -26493,14 +26470,16 @@ packages:
       escape-goat: 2.1.1
     dev: false
 
-  /purgecss-webpack-plugin/2.1.0_webpack@4.46.0:
+  /purgecss-webpack-plugin/2.1.0:
     resolution: {integrity: sha512-zbcGmlQ/RwI3tIFegZKE0KhP/G9I+IUbEgQkwEF/xkj4MBLODgy5Vg3sV/B1iAKD2jAoyfWYH+TjPd5nVgGslw==}
-    peerDependencies:
-      webpack: '*'
     dependencies:
       purgecss: 2.3.0
       webpack: 4.46.0
       webpack-sources: 1.4.3
+    transitivePeerDependencies:
+      - supports-color
+      - webpack-cli
+      - webpack-command
     dev: true
 
   /purgecss/2.3.0:
@@ -26874,6 +26853,14 @@ packages:
       react: 17.0.2
     dev: false
 
+  /react-clientside-effect/1.2.5_react@16.14.0:
+    resolution: {integrity: sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==}
+    peerDependencies:
+      react: ^15.3.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.18.9
+      react: 16.14.0
+
   /react-clientside-effect/1.2.5_react@17.0.2:
     resolution: {integrity: sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==}
     peerDependencies:
@@ -26881,16 +26868,11 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.9
       react: 17.0.2
+    dev: false
 
   /react-dev-utils/11.0.4_4rd6kybsuzfgmdyllug52nrldq:
     resolution: {integrity: sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==}
     engines: {node: '>=10'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.10.4
       address: 1.1.2
@@ -26921,7 +26903,9 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
+      - typescript
       - vue-template-compiler
+      - webpack
 
   /react-docgen-typescript-plugin/1.0.0_fh66qcvt6fztzjltdvxy4343yy:
     resolution: {integrity: sha512-Akc7EtryOA4d2yOX27B5ii+hyf/k15ymb01uB+VnRgtTAdfeDCmNPvyLbRJ6pRNYOuFlEBe1YfCH73bTPtpYVQ==}
@@ -26978,6 +26962,17 @@ packages:
       - supports-color
     dev: true
 
+  /react-dom/16.14.0_react@16.14.0:
+    resolution: {integrity: sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==}
+    peerDependencies:
+      react: ^16.14.0
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.7.2
+      react: 16.14.0
+      scheduler: 0.19.1
+
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
     peerDependencies:
@@ -26988,7 +26983,7 @@ packages:
       react: 17.0.2
       scheduler: 0.20.2
 
-  /react-element-to-jsx-string/14.3.2_sfoxds7t5ydpegc3knd667wn6m:
+  /react-element-to-jsx-string/14.3.2_zkbncb2mrwigeq3keybbaytzya:
     resolution: {integrity: sha512-WZbvG72cjLXAxV7VOuSzuHEaI3RHj10DZu8EcKQpkKcAj7+qAkG5XUeSdX5FXrA0vPrlx0QsnAzZEBJwzV0e+w==}
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
@@ -26996,7 +26991,7 @@ packages:
     dependencies:
       '@base2/pretty-print-object': 1.0.0
       is-plain-object: 3.0.1
-      react: 17.0.2
+      react: 16.14.0
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
@@ -27053,7 +27048,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /react-focus-lock/2.5.2_wl4y6gseskpemamwhbv27q43ni:
+  /react-focus-lock/2.5.2_nhp7wl2pwxhlzqos3czbs7ca5e:
     resolution: {integrity: sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -27061,14 +27056,14 @@ packages:
       '@babel/runtime': 7.18.9
       focus-lock: 0.9.1
       prop-types: 15.7.2
-      react: 17.0.2
-      react-clientside-effect: 1.2.5_react@17.0.2
-      use-callback-ref: 1.3.0_wl4y6gseskpemamwhbv27q43ni
-      use-sidecar: 1.1.2_wl4y6gseskpemamwhbv27q43ni
+      react: 16.14.0
+      react-clientside-effect: 1.2.5_react@16.14.0
+      use-callback-ref: 1.3.0_nhp7wl2pwxhlzqos3czbs7ca5e
+      use-sidecar: 1.1.2_nhp7wl2pwxhlzqos3czbs7ca5e
     transitivePeerDependencies:
       - '@types/react'
 
-  /react-helmet-async/1.0.9_sfoxds7t5ydpegc3knd667wn6m:
+  /react-helmet-async/1.0.9_wcqkhtmu7mswc6yz4uyexck3ty:
     resolution: {integrity: sha512-N+iUlo9WR3/u9qGMmP4jiYfaD6pe9IvDTapZLFJz2D3xlTlCM1Bzy4Ab3g72Nbajo/0ZyW+W9hdz8Hbe4l97pQ==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0
@@ -27077,8 +27072,8 @@ packages:
       '@babel/runtime': 7.18.9
       invariant: 2.2.4
       prop-types: 15.7.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
       react-fast-compare: 3.2.0
       shallowequal: 1.1.0
 
@@ -27182,28 +27177,28 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-popper-tooltip/2.11.1_sfoxds7t5ydpegc3knd667wn6m:
+  /react-popper-tooltip/2.11.1_wcqkhtmu7mswc6yz4uyexck3ty:
     resolution: {integrity: sha512-04A2f24GhyyMicKvg/koIOQ5BzlrRbKiAgP6L+Pdj1MVX3yJ1NeZ8+EidndQsbejFT55oW1b++wg2Z8KlAyhfQ==}
     peerDependencies:
       react: ^16.6.0
       react-dom: ^16.6.0
     dependencies:
       '@babel/runtime': 7.18.9
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-popper: 1.3.11_react@17.0.2
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      react-popper: 1.3.11_react@16.14.0
 
-  /react-popper/1.3.11_react@17.0.2:
+  /react-popper/1.3.11_react@16.14.0:
     resolution: {integrity: sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==}
     peerDependencies:
       react: 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.18.9
-      '@hypnosphi/create-react-context': 0.3.1_mv67koxdvxhyejehvpcoenu3ai
+      '@hypnosphi/create-react-context': 0.3.1_uutjjb2r36qagpytglxm7vtgnq
       deep-equal: 1.1.1
       popper.js: 1.16.1
       prop-types: 15.7.2
-      react: 17.0.2
+      react: 16.14.0
       typed-styles: 0.0.7
       warning: 4.0.3
 
@@ -27298,12 +27293,11 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-scripts/4.0.3_e5z7iwxxkielgwr442hoaozk7u:
+  /react-scripts/4.0.3_x42bqxgwliwa4f7rcvhhje7sti:
     resolution: {integrity: sha512-S5eO4vjUzUisvkIPB7jVsKtuH2HhWcASREYWHAQ1FP5HyCv3xgn+wpILAEWkmy+A+tTNbSZClhxjT3qz6g4L1A==}
     engines: {node: ^10.12.0 || >=12.0.0}
     hasBin: true
     peerDependencies:
-      eslint: '*'
       react: '>= 16'
       typescript: ^3.2.1 || ^4
     peerDependenciesMeta:
@@ -27448,7 +27442,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /react-syntax-highlighter/11.0.2_react@17.0.2:
+  /react-syntax-highlighter/11.0.2_react@16.14.0:
     resolution: {integrity: sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==}
     peerDependencies:
       react: '>= 0.14.0'
@@ -27457,7 +27451,7 @@ packages:
       highlight.js: 9.13.1
       lowlight: 1.11.0
       prismjs: 1.24.1
-      react: 17.0.2
+      react: 16.14.0
       refractor: 2.10.1
 
   /react-table/7.7.0_react@17.0.2:
@@ -27468,14 +27462,14 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-textarea-autosize/7.1.2_react@17.0.2:
+  /react-textarea-autosize/7.1.2_react@16.14.0:
     resolution: {integrity: sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==}
     peerDependencies:
       react: '>=0.14.0 <17.0.0'
     dependencies:
       '@babel/runtime': 7.18.9
       prop-types: 15.7.2
-      react: 17.0.2
+      react: 16.14.0
 
   /react-transition-group/4.4.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==}
@@ -28415,15 +28409,6 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: true
-
-  /restore-cursor/4.0.0:
-    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-    dev: true
 
   /ret/0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
@@ -28750,6 +28735,12 @@ packages:
     dependencies:
       xmlchars: 2.2.0
 
+  /scheduler/0.19.1:
+    resolution: {integrity: sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+
   /scheduler/0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
     dependencies:
@@ -28795,7 +28786,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scroll-smooth/1.1.0:
@@ -29235,15 +29226,15 @@ packages:
     dependencies:
       is-arrayish: 0.3.2
 
-  /simplebar-react/1.2.3_sfoxds7t5ydpegc3knd667wn6m:
+  /simplebar-react/1.2.3_wcqkhtmu7mswc6yz4uyexck3ty:
     resolution: {integrity: sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==}
     peerDependencies:
       react: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
       react-dom: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0
     dependencies:
       prop-types: 15.7.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
       simplebar: 4.2.3
 
   /simplebar/4.2.3:
@@ -29263,6 +29254,7 @@ packages:
       '@polka/url': 1.0.0-next.15
       mime: 2.5.2
       totalist: 1.1.0
+    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -29783,15 +29775,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  /string-width/5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.0.1
-    dev: true
 
   /string.prototype.matchall/4.0.5:
     resolution: {integrity: sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==}
@@ -30672,6 +30655,7 @@ packages:
       source-map: 0.6.1
       terser: 5.13.1
       webpack: 5.73.0_webpack-cli@4.10.0
+    dev: true
 
   /terser-webpack-plugin/5.3.1_zjtckeea76d3oit4tw4tcptpni:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -30870,6 +30854,7 @@ packages:
   /totalist/1.1.0:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
     engines: {node: '>=6'}
+    dev: true
 
   /tough-cookie/4.0.0:
     resolution: {integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==}
@@ -31298,11 +31283,6 @@ packages:
   /type-fest/0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
-
-  /type-fest/1.4.0:
-    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
-    engines: {node: '>=10'}
-    dev: true
 
   /type-is/1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -31840,6 +31820,20 @@ packages:
       react: 17.0.2
     dev: false
 
+  /use-callback-ref/1.3.0_nhp7wl2pwxhlzqos3czbs7ca5e:
+    resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.14
+      react: 16.14.0
+      tslib: 2.4.0
+
   /use-callback-ref/1.3.0_wl4y6gseskpemamwhbv27q43ni:
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
     engines: {node: '>=10'}
@@ -31853,6 +31847,7 @@ packages:
       '@types/react': 17.0.14
       react: 17.0.2
       tslib: 2.4.0
+    dev: false
 
   /use-isomorphic-layout-effect/1.1.1_wl4y6gseskpemamwhbv27q43ni:
     resolution: {integrity: sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==}
@@ -31878,6 +31873,21 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /use-sidecar/1.1.2_nhp7wl2pwxhlzqos3czbs7ca5e:
+    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.14
+      detect-node-es: 1.1.0
+      react: 16.14.0
+      tslib: 2.4.0
+
   /use-sidecar/1.1.2_wl4y6gseskpemamwhbv27q43ni:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -31892,6 +31902,7 @@ packages:
       detect-node-es: 1.1.0
       react: 17.0.2
       tslib: 2.4.0
+    dev: false
 
   /use-subscription/1.5.1_react@17.0.2:
     resolution: {integrity: sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==}
@@ -32211,6 +32222,7 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.9
+    dev: true
 
   /wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
@@ -32221,7 +32233,7 @@ packages:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
       defaults: 1.0.3
-    dev: true
+    dev: false
 
   /web-namespaces/1.1.4:
     resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
@@ -32277,6 +32289,7 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: true
 
   /webpack-bundle-size-analyzer/3.1.0:
     resolution: {integrity: sha512-8WlTT6uuCxZgZYNnCB0pRGukWRGH+Owg+HsqQUe1Zexakdno1eDYO+lE7ihBo9G0aCCZCJa8JWjYr9eLYfZrBA==}
@@ -32285,7 +32298,7 @@ packages:
       commander: 2.20.3
       filesize: 3.6.1
       humanize: 0.0.9
-    dev: false
+    dev: true
 
   /webpack-cli/3.3.12_webpack@5.39.1:
     resolution: {integrity: sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==}
@@ -32341,6 +32354,7 @@ packages:
       webpack: 5.73.0_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.6.1
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-cli/4.10.0_ptzbz4bao7we2onwdcwwuffqhy:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
@@ -32785,6 +32799,7 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: true
 
   /webpack-virtual-modules/0.2.2:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
@@ -33151,6 +33166,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
@@ -33639,15 +33655,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  /wrap-ansi/8.0.1:
-    resolution: {integrity: sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==}
-    engines: {node: '>=12'}
-    dependencies:
-      ansi-styles: 6.1.0
-      string-width: 5.1.2
-      strip-ansi: 7.0.1
-    dev: true
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,7 @@ importers:
       axios-mock-adapter: ^1.20.0
       boxen: ^5.1.2
       chalk: ^4.0.0
+      cli-progress: ^3.11.2
       cli-ux: ^6.0.9
       codecov: ^3.1.0
       command-exists: ^1.2.9
@@ -89,6 +90,7 @@ importers:
       lint-staged: ^11.1.2
       localtunnel: ^2.0.2
       nock: ^13.2.4
+      open: ^8.4.0
       prettier: ^2.4.1
       replace-json-property: ^1.4.1
       semver: ^7.3.7
@@ -101,6 +103,8 @@ importers:
       webpack-bundle-analyzer: ^4.6.1
       webpack-cli: ^4.10.0
     dependencies:
+      cli-progress: 3.11.2
+      open: 8.4.0
       webpack-bundle-analyzer: 4.6.1
     devDependencies:
       '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.16.7
@@ -15142,7 +15146,6 @@ packages:
   /define-lazy-prop/2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
-    dev: true
 
   /define-properties/1.1.3:
     resolution: {integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==}
@@ -23836,7 +23839,6 @@ packages:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
-    dev: true
 
   /openapi3-ts/2.0.2:
     resolution: {integrity: sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==}


### PR DESCRIPTION
- Created common bundle for all the entrypoint as we don't have multiple bin file. Earlier there were multiple entrypoint with no chunks.

Future: Further decrease by 50%
- Remove cLI-ux. It's deprecated. Use native packages. Currently it's including full fledged lodas, esprima, rxjs, etc. We don't need it.

[Done] - Decrease CLI size further. This need to verified thoroughly before mergin. Test would stop working as cli.action.stop won't work.